### PR TITLE
Improve FPS controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 <body>
   <div id="app"></div>
   <div class="crosshair"></div>
-  <div class="hint" id="hint">Click to lock the mouse. <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Click</b> to shoot, <b>Space</b> to jump.</div>
+  <div class="hint" id="hint">Middle-click to lock the mouse. <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left click</b> to shoot, <b>Space</b> to jump.</div>
   <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
 
   <script type="module">
@@ -169,7 +169,7 @@
 
     // --- Bullets ---
     const bullets = [];
-    const bulletGeo = new THREE.SphereGeometry(0.06, 12, 8);
+    const bulletGeo = new THREE.SphereGeometry(0.12, 12, 8);
     const bulletMat = new THREE.MeshBasicMaterial({ color: 0xffffee });
 
     function shoot(){
@@ -194,12 +194,12 @@
 
     // Pointer lock for mouse look
     const hint = document.getElementById('hint');
-    addEventListener('click', () => {
-      if (!pointerLocked) {
+    addEventListener('mousedown', (e) => {
+      if (e.button === 1 && !pointerLocked) {
         renderer.domElement.requestPointerLock();
-      } else {
-        // left click while locked shoots
-        shoot();
+      } else if (e.button === 0) {
+        // left mouse shoots when pointer is locked
+        if (pointerLocked) shoot();
       }
     });
 
@@ -223,7 +223,7 @@
     function update(dt){
       // Move on XZ using yaw (aim direction)
       const speed = (keys.has('ShiftLeft')||keys.has('ShiftRight')) ? 10 : 6;
-      const forward = new THREE.Vector3(Math.sin(yaw), 0, Math.cos(yaw));
+      const forward = new THREE.Vector3(-Math.sin(yaw), 0, -Math.cos(yaw));
       const right   = new THREE.Vector3(Math.cos(yaw), 0, -Math.sin(yaw));
       let move = new THREE.Vector3();
       if (keys.has('KeyW')) move.add(forward);
@@ -269,6 +269,7 @@
       for (let i=bullets.length-1;i>=0;i--){
         const b = bullets[i];
         b.mesh.position.addScaledVector(b.vel, dt);
+        b.mesh.scale.multiplyScalar(0.98);
         // remove old or out-of-bounds bullets
         if (now - b.born > 3000 || b.mesh.position.length() > groundSize) {
           scene.remove(b.mesh); bullets.splice(i,1);


### PR DESCRIPTION
## Summary
- enable middle click to lock pointer for camera look
- fix WASD movement orientation for FPS-style controls
- allow left-click shooting with visible shrinking bullets

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c74f8ce62083218a500408ae6972af