### PR TITLE
Improve camera controls and pointer lock

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 <body>
   <div id="app"></div>
   <div class="crosshair"></div>
-  <div class="hint" id="hint">Middle‑click to lock the mouse. <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
+  <div class="hint" id="hint">Click to lock the mouse, press <b>Esc</b> to unlock. <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
   <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
 
   <script type="module">
@@ -166,6 +166,8 @@
 
     // Camera offset relative to player in local space (over‑the‑shoulder)
     const camOffset = new THREE.Vector3(-2.5, 1.8, 3.8); // left shoulder & back
+    const headOffset = new THREE.Vector3(0, 1.3, 0);     // approximate head height
+    const baseCamOffset = camOffset.clone().sub(headOffset); // pivot around head
 
     // --- Bullets ---
     const bullets = [];
@@ -189,17 +191,21 @@
     }
 
     // --- Input ---
-    addEventListener('keydown', e=>{ keys.add(e.code); });
+    addEventListener('keydown', e=>{
+      if (e.code === 'Escape' && pointerLocked) {
+        document.exitPointerLock();
+      } else {
+        keys.add(e.code);
+      }
+    });
     addEventListener('keyup',   e=>{ keys.delete(e.code); });
 
     // Pointer lock for mouse look
     const hint = document.getElementById('hint');
     addEventListener('mousedown', (e) => {
-      if (e.button === 1 && !pointerLocked) {
-        // middle mouse initiates pointer lock
+      if (!pointerLocked) {
         renderer.domElement.requestPointerLock();
-        e.preventDefault();
-      } else if (e.button === 0 && pointerLocked) {
+      } else if (e.button === 0) {
         // left click while locked shoots
         shoot();
       }
@@ -213,7 +219,7 @@
     addEventListener('mousemove', e=>{
       if(!pointerLocked) return;
       const sensitivity = 0.0027;
-      yaw   -= e.movementX * sensitivity;
+      yaw   += e.movementX * sensitivity;
       pitch -= e.movementY * sensitivity;
       pitch = Math.max(-Math.PI/3, Math.min(Math.PI/3, pitch));
     });
@@ -250,21 +256,15 @@
       // Aim the right arm toward where camera looks (rough)
       armR.rotation.x = -pitch * 0.75;
 
-      // Update camera behind/over shoulder
-      const q = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, yaw, 0));
-      const offsetWorld = camOffset.clone().applyQuaternion(q);
-      const camPos = player.position.clone().add(offsetWorld);
+      // Update camera orbiting around player
+      const pivot = player.position.clone().add(headOffset);
+      const rot = new THREE.Quaternion().setFromEuler(new THREE.Euler(pitch, yaw, 0, 'YXZ'));
+      const offsetWorld = baseCamOffset.clone().applyQuaternion(rot);
+      const camPos = pivot.clone().add(offsetWorld);
       camera.position.lerp(camPos, 0.85); // smoothed
 
-      // Camera look target slightly above player
-      const lookTarget = player.position.clone().add(new THREE.Vector3(0, 1.3, 0));
-      const targetDir = lookTarget.clone().sub(camera.position).normalize();
-
-      // Apply pitch around player's right vector
-      const rightVec = new THREE.Vector3().crossVectors(new THREE.Vector3(0,1,0), targetDir).normalize();
-      const pitched = targetDir.clone().applyAxisAngle(rightVec, pitch);
-      const camAim = camera.position.clone().add(pitched);
-      camera.lookAt(camAim);
+      // Camera looks at the pivot (player head)
+      camera.lookAt(pivot);
 
       // Bullets update
       const now = performance.now();
@@ -293,8 +293,9 @@
 
     // Spawn position and initial camera placement
     player.position.set(0,0,8);
-    camera.position.set(-2.5, 2.2, 12);
-    camera.lookAt(player.position.x, 1.3, player.position.z);
+    const spawnPivot = player.position.clone().add(headOffset);
+    camera.position.copy(spawnPivot.clone().add(baseCamOffset));
+    camera.lookAt(spawnPivot);
 
     // Resize
     addEventListener('resize', ()=>{


### PR DESCRIPTION
## Summary
- Use regular left-click to lock the mouse and allow Esc to release pointer lock
- Swap yaw direction to remove inverted mouse control
- Orbit the camera around the player's head for more intuitive aiming

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c751c8badc8321b6cd9721fc026c47