### PR TITLE
Add configurable ball dispensers and bouncers

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,12 +35,25 @@
       text-align: center;
     }
     .hidden { display: none; }
+    .panel {
+      position: fixed; top: 16px; right: 16px;
+      padding: 10px 14px; border-radius: 14px;
+      background: rgba(20,22,24,0.65); color: #e9eef5;
+      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
+      user-select: none;
+    }
+    .panel input { width: 160px; }
   </style>
 </head>
 <body>
   <div id="app"></div>
   <div class="crosshair"></div>
   <div class="hint" id="hint">Middle‑click to lock the mouse. <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
+  <div class="panel">
+    <label>Dispenser Balls: <span id="ballCountValue">2000</span></label><br>
+    <input type="range" id="ballCountSlider" min="100" max="10000" value="2000">
+  </div>
   <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
 
   <script type="module">
@@ -57,6 +70,18 @@
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x7fb0ff);
     scene.fog = new THREE.Fog(0x7fb0ff, 20, 140);
+
+    // --- UI Controls ---
+    const ballCountSlider = document.getElementById('ballCountSlider');
+    const ballCountValue  = document.getElementById('ballCountValue');
+    let maxBalls = parseInt(ballCountSlider.value, 10);
+    let totalDispensed = 0;
+    ballCountValue.textContent = maxBalls;
+    ballCountSlider.addEventListener('input', () => {
+      maxBalls = parseInt(ballCountSlider.value, 10);
+      ballCountValue.textContent = maxBalls;
+      totalDispensed = 0;
+    });
 
     // --- Camera (third‑person follow) ---
     const camera = new THREE.PerspectiveCamera(70, innerWidth/innerHeight, 0.1, 500);
@@ -224,10 +249,17 @@
     // Camera offset relative to player in local space (over‑the‑shoulder)
     const camOffset = new THREE.Vector3(-2.5, 1.8, 3.8); // left shoulder & back
 
-    // --- Bullets ---
-    const bullets = [];
-    const bulletGeo = new THREE.SphereGeometry(0.1, 12, 8);
-    const bulletMat = new THREE.MeshBasicMaterial({ color: 0xffffee });
+    // --- Balls ---
+    const balls = [];
+    const ballGeo = new THREE.SphereGeometry(0.1, 12, 8);
+    const ballMat = new THREE.MeshBasicMaterial({ color: 0xffffee });
+
+    function spawnBall(position, velocity) {
+      const mesh = new THREE.Mesh(ballGeo, ballMat);
+      mesh.position.copy(position);
+      scene.add(mesh);
+      balls.push({ mesh, vel: velocity, radius: 0.1 });
+    }
 
     function shoot(){
       // Muzzle position slightly in front/right of player chest, aligned with aim
@@ -238,11 +270,38 @@
       const dir = new THREE.Vector3();
       camera.getWorldDirection(dir);
 
-      const mesh = new THREE.Mesh(bulletGeo, bulletMat);
-      mesh.position.copy(muzzleWorld);
-      scene.add(mesh);
+      spawnBall(muzzleWorld, dir.multiplyScalar(38));
+    }
 
-      bullets.push({ mesh, vel: dir.multiplyScalar(38), born: performance.now() });
+    // --- Dispensers & Bouncers ---
+    const dispensers = [];
+    const bouncers = [];
+
+    function addDispenser(pos){
+      const geo = new THREE.BoxGeometry(0.6,0.6,0.6);
+      const mat = new THREE.MeshLambertMaterial({ color: 0x8888ff });
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.copy(pos);
+      mesh.castShadow = mesh.receiveShadow = true;
+      scene.add(mesh);
+      dispensers.push({ mesh, lastSpawn: 0 });
+    }
+
+    function addBouncer(pos, radius){
+      const geo = new THREE.SphereGeometry(radius, 16, 12);
+      const mat = new THREE.MeshLambertMaterial({ color: 0xff5555 });
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.copy(pos);
+      mesh.castShadow = mesh.receiveShadow = true;
+      scene.add(mesh);
+      bouncers.push({ mesh, radius });
+    }
+
+    addDispenser(new THREE.Vector3(-12,0.3,-12));
+    addDispenser(new THREE.Vector3(12,0.3,-12));
+    addDispenser(new THREE.Vector3(0,0.3,12));
+    for (let i=0;i<5;i++){
+      addBouncer(new THREE.Vector3(rng(-20,20),1,rng(-20,20)), rng(1,3));
     }
 
     // --- Input ---
@@ -323,16 +382,53 @@
       const camAim = camera.position.clone().add(pitched);
       camera.lookAt(camAim);
 
-      // Bullets update
-      const now = performance.now();
-      for (let i=bullets.length-1;i>=0;i--){
-        const b = bullets[i];
+      // Balls update
+      for (let i=balls.length-1;i>=0;i--){
+        const b = balls[i];
+        b.vel.y -= GRAV * dt;
         b.mesh.position.addScaledVector(b.vel, dt);
-        const life = (now - b.born) / 3000;
-        b.mesh.scale.setScalar(Math.max(0, 1 - life));
-        // remove old or out-of-bounds bullets
-        if (life > 1 || b.mesh.position.length() > groundSize) {
-          scene.remove(b.mesh); bullets.splice(i,1);
+
+        // ground bounce
+        if (b.mesh.position.y - b.radius <= 0){
+          b.mesh.position.y = b.radius;
+          if (b.vel.y < 0){
+            b.vel.y *= -0.7;
+            b.mesh.scale.multiplyScalar(0.7);
+            b.radius *= 0.7;
+          }
+        }
+
+        // bouncer collisions
+        for (const ob of bouncers){
+          const diff = b.mesh.position.clone().sub(ob.mesh.position);
+          const dist = diff.length();
+          const minDist = b.radius + ob.radius;
+          if (dist < minDist){
+            diff.normalize();
+            const vDotN = b.vel.dot(diff);
+            if (vDotN < 0){
+              b.vel.addScaledVector(diff, -2 * vDotN);
+              b.mesh.position.addScaledVector(diff, minDist - dist);
+              b.mesh.scale.multiplyScalar(0.7);
+              b.radius *= 0.7;
+            }
+          }
+        }
+
+        // remove tiny or out-of-bounds balls
+        if (b.radius < 0.02 || b.mesh.position.length() > groundSize){
+          scene.remove(b.mesh); balls.splice(i,1);
+        }
+      }
+
+      // Dispensers spawn
+      const now = performance.now();
+      for (const d of dispensers){
+        if (totalDispensed < maxBalls && now - d.lastSpawn >= 1000){
+          const dir = new THREE.Vector3(Math.random()-0.5, 0.5, Math.random()-0.5).normalize();
+          spawnBall(d.mesh.position.clone(), dir.multiplyScalar(10));
+          d.lastSpawn = now;
+          totalDispensed++;
         }
       }
 


### PR DESCRIPTION
## Summary
- add UI slider to configure total balls dispensers release
- introduce ball dispensers and red bouncer obstacles
- shrink balls on every bounce and spawn from dispensers each second

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c754efabbc832186f35f92c5239109