### PR TITLE
Add configurable ball dispensers

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,16 @@
       text-align: center;
     }
     .hidden { display: none; }
+
+    .panel {
+      position: fixed; top: 16px; left: 16px;
+      padding: 10px 14px; border-radius: 14px;
+      background: rgba(20,22,24,0.65); color: #e9eef5;
+      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
+      user-select: none;
+    }
+    .panel input[type=range] { width: 160px; }
   </style>
 </head>
 <body>
@@ -42,6 +52,7 @@
   <div class="crosshair"></div>
   <div class="hint" id="hint">Middle‑click to lock the mouse. <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
   <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
+  <div class="panel">Balls: <input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
 
   <script type="module">
     import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
@@ -53,6 +64,15 @@
     renderer.setSize(innerWidth, innerHeight);
     renderer.shadowMap.enabled = true;
     app.appendChild(renderer.domElement);
+
+    // UI controls
+    const ballSlider = document.getElementById('ballSlider');
+    const ballCountLabel = document.getElementById('ballCountLabel');
+    let maxBalls = parseInt(ballSlider.value);
+    ballSlider.addEventListener('input', () => {
+      ballCountLabel.textContent = ballSlider.value;
+      maxBalls = parseInt(ballSlider.value);
+    });
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x7fb0ff);
@@ -229,6 +249,28 @@
     const bulletGeo = new THREE.SphereGeometry(0.1, 12, 8);
     const bulletMat = new THREE.MeshBasicMaterial({ color: 0xffffee });
 
+    // Dispensers and balls
+    const BALL_RADIUS = 0.4;
+    const ballGeo = new THREE.SphereGeometry(BALL_RADIUS, 16, 12);
+    const ballMat = new THREE.MeshLambertMaterial({ color: 0xffaa33 });
+    const dispensers = [
+      { pos: new THREE.Vector3(8, 0, 8), last: 0 },
+      { pos: new THREE.Vector3(-8, 0, -8), last: 0 },
+      { pos: new THREE.Vector3(-8, 0, 8), last: 0 }
+    ];
+    const balls = [];
+    let totalDispensed = 0;
+
+    // visualize dispensers
+    const dispGeo = new THREE.CylinderGeometry(0.5, 0.5, 1, 16);
+    const dispMat = new THREE.MeshLambertMaterial({ color: 0x555555 });
+    for (const d of dispensers) {
+      const m = new THREE.Mesh(dispGeo, dispMat);
+      m.position.copy(d.pos);
+      m.castShadow = true; m.receiveShadow = true;
+      scene.add(m);
+    }
+
     function shoot(){
       // Muzzle position slightly in front/right of player chest, aligned with aim
       const muzzle = new THREE.Vector3(0.4, 1.3, -0.2);
@@ -280,6 +322,7 @@
     const GRAV = 22;
 
     function update(dt){
+      const now = performance.now();
       // Move on XZ using yaw (aim direction)
       const speed = (keys.has('ShiftLeft')||keys.has('ShiftRight')) ? 10 : 6;
       const forward = new THREE.Vector3(-Math.sin(yaw), 0, -Math.cos(yaw));
@@ -323,16 +366,55 @@
       const camAim = camera.position.clone().add(pitched);
       camera.lookAt(camAim);
 
-      // Bullets update
-      const now = performance.now();
+      // Spawn balls from dispensers
+      for (const d of dispensers) {
+        if (totalDispensed >= maxBalls) break;
+        if (now - d.last >= 1000) {
+          const mesh = new THREE.Mesh(ballGeo, ballMat);
+          mesh.position.copy(d.pos).add(new THREE.Vector3(0, BALL_RADIUS, 0));
+          mesh.castShadow = true; mesh.receiveShadow = true;
+          scene.add(mesh);
+          const dir = new THREE.Vector3(Math.random() - 0.5, 0.5, Math.random() - 0.5).normalize();
+          balls.push({ mesh, vel: dir.multiplyScalar(6) });
+          d.last = now;
+          totalDispensed++;
+        }
+      }
+
+      // Update balls
+      for (let i = balls.length - 1; i >= 0; i--) {
+        const b = balls[i];
+        b.vel.y -= GRAV * dt;
+        b.mesh.position.addScaledVector(b.vel, dt);
+        if (b.mesh.position.y < BALL_RADIUS) {
+          b.mesh.position.y = BALL_RADIUS;
+          b.vel.y *= -0.6;
+        }
+        if (b.mesh.position.length() > groundSize) {
+          scene.remove(b.mesh); balls.splice(i,1);
+        }
+      }
+
+      // Bullets update and collision with balls
       for (let i=bullets.length-1;i>=0;i--){
         const b = bullets[i];
         b.mesh.position.addScaledVector(b.vel, dt);
         const life = (now - b.born) / 3000;
         b.mesh.scale.setScalar(Math.max(0, 1 - life));
-        // remove old or out-of-bounds bullets
         if (life > 1 || b.mesh.position.length() > groundSize) {
-          scene.remove(b.mesh); bullets.splice(i,1);
+          scene.remove(b.mesh); bullets.splice(i,1); continue;
+        }
+        for (let j = balls.length - 1; j >= 0; j--) {
+          const ball = balls[j];
+          const radius = BALL_RADIUS * ball.mesh.scale.x;
+          if (b.mesh.position.distanceTo(ball.mesh.position) < radius + 0.1) {
+            ball.mesh.scale.multiplyScalar(0.7);
+            scene.remove(b.mesh); bullets.splice(i,1);
+            if (ball.mesh.scale.x < 0.2) {
+              scene.remove(ball.mesh); balls.splice(j,1);
+            }
+            break;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Add on-screen slider to configure total balls dispensed (100-10,000)
- Spawn ball dispensers that fire a ball every second until the global limit is reached
- Balls shrink when shot by the player and disappear when small

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c754efabbc832186f35f92c5239109