### PR TITLE
feat: add day-night cycle and rabbit encounter

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,28 @@
       user-select: none;
     }
     .panel input[type=range] { width: 160px; }
+
+    .timer {
+      position: fixed; top: 16px; right: 16px; width: 64px; height: 64px;
+    }
+    .timer svg { position: absolute; inset: 0; transform: rotate(-90deg); }
+    .timer circle {
+      fill: none; stroke: #fff; stroke-width: 6; opacity: 0.5;
+      stroke-dasharray: 283; stroke-dashoffset: 283;
+    }
+    .timer .icon {
+      position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+      font-size: 32px;
+    }
+
+    .hud {
+      position: fixed; left: 16px; bottom: 16px;
+      padding: 8px 12px; border-radius: 10px;
+      background: rgba(20,22,24,0.65); color: #e9eef5;
+      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
+      user-select: none; pointer-events: none;
+    }
   </style>
 </head>
 <body>
@@ -53,6 +75,13 @@
     <div class="hint" id="hint">Click to lock the mouse (<b>Esc</b> to release). <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
   <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
   <div class="panel">Balls: <input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
+  <div id="cycle" class="timer">
+    <svg viewBox="0 0 100 100">
+      <circle id="cycleProgress" cx="50" cy="50" r="45"></circle>
+    </svg>
+    <div class="icon" id="cycleIcon">☀️</div>
+  </div>
+  <div id="health" class="hud">Health: <span id="healthVal">100</span></div>
 
   <script type="module" src="js/main.js"></script>
 </body>

--- a/js/dayNight.js
+++ b/js/dayNight.js
@@ -1,0 +1,53 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+
+export class DayNightCycle {
+  constructor(scene, sun, hemi) {
+    this.scene = scene;
+    this.sun = sun;
+    this.hemi = hemi;
+    this.duration = 60000; // 60s for a full cycle
+    this.start = performance.now();
+    this.circle = document.getElementById('cycleProgress');
+    this.icon = document.getElementById('cycleIcon');
+    const r = 45;
+    this.circumference = 2 * Math.PI * r;
+    if (this.circle) {
+      this.circle.style.strokeDasharray = `${this.circumference}`;
+      this.circle.style.strokeDashoffset = `${this.circumference}`;
+    }
+    this.night = false;
+  }
+
+  update(now) {
+    const elapsed = (now - this.start) % this.duration;
+    const t = elapsed / this.duration;
+    if (this.circle) {
+      this.circle.style.strokeDashoffset = `${this.circumference * (1 - t)}`;
+    }
+    const nightNow = t >= 0.5;
+    if (nightNow !== this.night) {
+      this.night = nightNow;
+      if (nightNow) {
+        this.icon.textContent = '🌙';
+        this.scene.background.set(0x000000);
+        this.scene.fog.color.set(0x000000);
+        this.scene.fog.near = 2;
+        this.scene.fog.far = 40;
+        this.sun.intensity = 0.1;
+        this.hemi.intensity = 0.1;
+      } else {
+        this.icon.textContent = '☀️';
+        this.scene.background.set(0x7fb0ff);
+        this.scene.fog.color.set(0x7fb0ff);
+        this.scene.fog.near = 20;
+        this.scene.fog.far = 140;
+        this.sun.intensity = 1.0;
+        this.hemi.intensity = 0.6;
+      }
+    }
+  }
+
+  isNight() {
+    return this.night;
+  }
+}

--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -1,0 +1,110 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+
+function makeRabbitMesh() {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(
+    new THREE.SphereGeometry(1.2, 16, 16),
+    new THREE.MeshLambertMaterial({ color: 0xffffff })
+  );
+  body.position.y = 1.2; body.castShadow = true; body.receiveShadow = true;
+
+  const head = new THREE.Mesh(
+    new THREE.SphereGeometry(0.8, 16, 16),
+    new THREE.MeshLambertMaterial({ color: 0xffffff })
+  );
+  head.position.y = 2.1; head.castShadow = true;
+
+  const earGeo = new THREE.BoxGeometry(0.3, 1.2, 0.3);
+  const earMat = new THREE.MeshLambertMaterial({ color: 0xffffff });
+  const earL = new THREE.Mesh(earGeo, earMat);
+  earL.position.set(-0.35, 2.8, 0); earL.castShadow = true;
+  const earR = earL.clone(); earR.position.x = 0.35;
+
+  const eyeGeo = new THREE.SphereGeometry(0.12, 8, 8);
+  const eyeMat = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+  const eyeL = new THREE.Mesh(eyeGeo, eyeMat); eyeL.position.set(-0.2, 2.2, 0.55);
+  const eyeR = eyeL.clone(); eyeR.position.x = 0.2;
+
+  const blood = new THREE.Mesh(
+    new THREE.PlaneGeometry(1.4, 0.6),
+    new THREE.MeshBasicMaterial({ color: 0x8b0000 })
+  );
+  blood.rotation.x = -Math.PI/2; blood.position.set(0, 0, -0.8);
+
+  g.add(body, head, earL, earR, eyeL, eyeR, blood);
+  g.scale.set(2.2, 2.2, 2.2);
+  return g;
+}
+
+function makeCave(scene) {
+  const cave = new THREE.Mesh(
+    new THREE.CylinderGeometry(2, 2, 3, 12, 1, true),
+    new THREE.MeshLambertMaterial({ color: 0x333333, side: THREE.DoubleSide })
+  );
+  cave.rotation.z = Math.PI / 2;
+  cave.position.set(30, 1.5, 30);
+  scene.add(cave);
+  return cave;
+}
+
+export class Rabbit {
+  constructor(scene, player, changeHealth) {
+    this.scene = scene;
+    this.player = player;
+    this.changeHealth = changeHealth;
+    this.obj = makeRabbitMesh();
+    this.cave = makeCave(scene);
+    this.state = 'idle';
+    this.visible = false;
+    this.tookHealth = false;
+  }
+
+  startNight() {
+    this.obj.position.copy(this.cave.position);
+    this.scene.add(this.obj);
+    this.visible = true;
+    this.state = 'attack';
+    this.tookHealth = false;
+  }
+
+  endNight() {
+    if (this.visible) this.scene.remove(this.obj);
+    this.visible = false;
+    this.state = 'idle';
+  }
+
+  kick() {
+    if (this.state === 'drag') {
+      this.state = 'flee';
+    }
+  }
+
+  isDragging() {
+    return this.state === 'drag';
+  }
+
+  update(dt) {
+    if (!this.visible) return;
+    if (this.state === 'attack') {
+      const dir = this.player.position.clone().sub(this.obj.position).normalize();
+      this.obj.position.addScaledVector(dir, dt * 4);
+      if (this.obj.position.distanceTo(this.player.position) < 1) {
+        this.state = 'drag';
+      }
+    } else if (this.state === 'drag') {
+      if (!this.tookHealth) {
+        this.changeHealth(0.5);
+        this.tookHealth = true;
+      }
+      const dir = this.cave.position.clone().sub(this.obj.position).normalize();
+      this.obj.position.addScaledVector(dir, dt * 3);
+      this.player.position.copy(this.obj.position.clone().add(dir.multiplyScalar(-1)));
+    } else if (this.state === 'flee') {
+      const dir = this.cave.position.clone().sub(this.obj.position).normalize();
+      this.obj.position.addScaledVector(dir, dt * 6);
+      if (this.obj.position.distanceTo(this.cave.position) < 0.5) {
+        this.endNight();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add circular day/night timer UI with sun/moon icons
- implement day/night cycle that darkens scene and spawns rabbit at night
- create rabbit enemy that drags player and can be kicked to flee

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c759944bb08321999bdc70f2be97dc