### PR TITLE
Align bullet trajectory with crosshair

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -179,9 +179,12 @@ function shootBullet(){
   const muzzle = new THREE.Vector3(0.4, 1.3, -0.2);
   const muzzleWorld = player.localToWorld(muzzle.clone());
 
-  // Forward direction from camera (aim)
-  const dir = new THREE.Vector3();
-  camera.getWorldDirection(dir);
+  // Determine aim direction so bullets travel through the crosshair
+  const aimDir = new THREE.Vector3();
+  camera.getWorldDirection(aimDir);
+  // Choose a far point along the camera's forward ray and aim from the muzzle
+  const target = camera.position.clone().addScaledVector(aimDir, 1000);
+  const dir = target.sub(muzzleWorld).normalize();
 
   const mesh = new THREE.Mesh(bulletGeo, bulletMat);
   mesh.position.copy(muzzleWorld);


### PR DESCRIPTION
## Summary
- aim bullets through screen center even when firing from an offset muzzle

## Testing
- `node --check js/game.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68c75c5049dc832196d742ec09cb2ff8