### PR TITLE
Align bullets with crosshair in third-person view

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -179,9 +179,12 @@ function shootBullet(){
   const muzzle = new THREE.Vector3(0.4, 1.3, -0.2);
   const muzzleWorld = player.localToWorld(muzzle.clone());
 
-  // Forward direction from camera (aim)
-  const dir = new THREE.Vector3();
-  camera.getWorldDirection(dir);
+  // Calculate direction so bullets travel through the center crosshair
+  // Cast a far point from the camera forward and aim from the muzzle to it
+  const aimDir = new THREE.Vector3();
+  camera.getWorldDirection(aimDir);
+  const farPoint = camera.position.clone().addScaledVector(aimDir, 1000);
+  const dir = farPoint.sub(muzzleWorld).normalize();
 
   const mesh = new THREE.Mesh(bulletGeo, bulletMat);
   mesh.position.copy(muzzleWorld);


### PR DESCRIPTION
## Summary
- Aim bullets from the muzzle towards a point through the center crosshair so shots follow the cursor even with an offset camera.

## Testing
- `node --check js/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c75c5049dc832196d742ec09cb2ff8