### PR TITLE
Add night ambience and proximity rabbit screams

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -25,8 +25,19 @@ const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x7fb0ff);
 scene.fog = new THREE.Fog(0x7fb0ff, 20, 140);
 
-// --- Camera (third‑person follow) ---
-const camera = new THREE.PerspectiveCamera(70, innerWidth/innerHeight, 0.1, 500);
+  // --- Camera (third‑person follow) ---
+  const camera = new THREE.PerspectiveCamera(70, innerWidth/innerHeight, 0.1, 500);
+
+  // Audio setup
+  const listener = new THREE.AudioListener();
+  camera.add(listener);
+  const audioLoader = new THREE.AudioLoader();
+  const nightSound = new THREE.Audio(listener);
+  audioLoader.load('audio/horror-drone.wav', (buffer) => {
+    nightSound.setBuffer(buffer);
+    nightSound.setLoop(true);
+    nightSound.setVolume(0.5);
+  });
 
 // --- Lights ---
 const hemi = new THREE.HemisphereLight(0xffffff, 0x335533, 0.6);
@@ -138,15 +149,15 @@ function updateHealthUI() {
 }
 
 // Rabbits and day/night cycle
-const rabbits = [
-  new Rabbit(scene, player, 1, {
-    onTrap: () => { controls.trappedUntil = performance.now() + 2000; }
-  }),
-  new Rabbit(scene, player, 2),
-  new Rabbit(scene, player, 3, {
-    onAttack: () => { playerHealth *= 0.5; updateHealthUI(); }
-  })
-];
+  const rabbits = [
+    new Rabbit(scene, player, 1, {
+      onTrap: () => { controls.trappedUntil = performance.now() + 2000; }
+    }, listener, audioLoader),
+    new Rabbit(scene, player, 2, {}, listener, audioLoader),
+    new Rabbit(scene, player, 3, {
+      onAttack: () => { playerHealth *= 0.5; updateHealthUI(); }
+    }, listener, audioLoader)
+  ];
 const dayNight = new DayNightCycle(scene, sun, hemi);
 controls.trappedUntil = 0;
 
@@ -212,9 +223,14 @@ initControls(renderer.domElement, handleClick);
 let velY = 0; // vertical velocity for jumping/gravity
 const GRAV = 22;
 
-function update(dt){
-  dayNight.update(dt);
-  const { yaw, pitch, keys } = controls;
+  function update(dt){
+    dayNight.update(dt);
+    if (dayNight.isNight) {
+      if (nightSound.buffer && !nightSound.isPlaying) nightSound.play();
+    } else if (nightSound.isPlaying) {
+      nightSound.stop();
+    }
+    const { yaw, pitch, keys } = controls;
   const now = performance.now();
   // Move on XZ using yaw (aim direction)
   const speed = (keys.has('ShiftLeft')||keys.has('ShiftRight')) ? 10 : 6;

--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -56,8 +56,8 @@ function createCave() {
   return m;
 }
 
-export class Rabbit {
-  constructor(scene, player, type, callbacks = {}) {
+  export class Rabbit {
+  constructor(scene, player, type, callbacks = {}, listener, audioLoader) {
     this.scene = scene;
     this.player = player;
     this.type = type; // 1,2,3
@@ -95,6 +95,17 @@ export class Rabbit {
     this.healthBar.appendChild(this.healthFill);
     this.healthBar.appendChild(this.healthLabel);
     document.body.appendChild(this.healthBar);
+
+    // proximity scream audio
+    this.screamSound = new THREE.PositionalAudio(listener);
+    audioLoader.load('audio/scream.wav', (buffer) => {
+      this.screamSound.setBuffer(buffer);
+      this.screamSound.setRefDistance(5);
+      this.screamSound.setRolloffFactor(2);
+      this.screamSound.setLoop(false);
+    });
+    this.mesh.add(this.screamSound);
+    this.lastScream = 0;
   }
 
   startNight() {
@@ -112,6 +123,7 @@ export class Rabbit {
       this.visible = false;
       this.mesh.position.copy(this.home.clone().add(new THREE.Vector3(0, 0, 2)));
     }
+    if (this.screamSound.isPlaying) this.screamSound.stop();
   }
 
   damage(amount) {
@@ -154,11 +166,18 @@ export class Rabbit {
         } else {
           this.endNight();
         }
-      } else if (this.isDragging) {
-        const dir = this.home.clone().sub(this.player.position).setY(0).normalize();
-        this.player.position.addScaledVector(dir, 2 * dt);
-        this.mesh.position.copy(this.player.position);
-      } else {
+        } else if (this.isDragging) {
+          const dir = this.home.clone().sub(this.player.position).setY(0).normalize();
+          this.player.position.addScaledVector(dir, 2 * dt);
+          this.mesh.position.copy(this.player.position);
+          if (isNight) {
+            const now = performance.now();
+            if (!this.screamSound.isPlaying && this.screamSound.buffer && now - this.lastScream > 3000) {
+              this.screamSound.play();
+              this.lastScream = now;
+            }
+          }
+        } else {
         const dir = this.player.position.clone().sub(this.mesh.position);
         dir.y = 0;
         const dist = dir.length();


### PR DESCRIPTION
## Summary
- Play looping horror drone audio during night cycles
- Add positional scream audio for attacking rabbits that triggers every 3 seconds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7618cf2e4832185f9d66c8dcc91e8