### PR TITLE
Add night ambient and rabbit scream audio

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -28,6 +28,18 @@ scene.fog = new THREE.Fog(0x7fb0ff, 20, 140);
 // --- Camera (third‑person follow) ---
 const camera = new THREE.PerspectiveCamera(70, innerWidth/innerHeight, 0.1, 500);
 
+// Audio setup
+const listener = new THREE.AudioListener();
+camera.add(listener);
+const audioLoader = new THREE.AudioLoader();
+const droneSound = new THREE.Audio(listener);
+audioLoader.load('audio/horror-drone.wav', (buffer) => {
+  droneSound.setBuffer(buffer);
+  droneSound.setLoop(true);
+  droneSound.setVolume(0.4);
+});
+let wasNight = false;
+
 // --- Lights ---
 const hemi = new THREE.HemisphereLight(0xffffff, 0x335533, 0.6);
 scene.add(hemi);
@@ -141,11 +153,11 @@ function updateHealthUI() {
 const rabbits = [
   new Rabbit(scene, player, 1, {
     onTrap: () => { controls.trappedUntil = performance.now() + 2000; }
-  }),
-  new Rabbit(scene, player, 2),
+  }, listener),
+  new Rabbit(scene, player, 2, {}, listener),
   new Rabbit(scene, player, 3, {
     onAttack: () => { playerHealth *= 0.5; updateHealthUI(); }
-  })
+  }, listener)
 ];
 const dayNight = new DayNightCycle(scene, sun, hemi);
 controls.trappedUntil = 0;
@@ -214,6 +226,13 @@ const GRAV = 22;
 
 function update(dt){
   dayNight.update(dt);
+  if (dayNight.isNight && !wasNight) {
+    if (droneSound.buffer) droneSound.play();
+  }
+  if (!dayNight.isNight && wasNight) {
+    if (droneSound.isPlaying) droneSound.stop();
+  }
+  wasNight = dayNight.isNight;
   const { yaw, pitch, keys } = controls;
   const now = performance.now();
   // Move on XZ using yaw (aim direction)

--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -57,7 +57,7 @@ function createCave() {
 }
 
 export class Rabbit {
-  constructor(scene, player, type, callbacks = {}) {
+  constructor(scene, player, type, callbacks = {}, listener) {
     this.scene = scene;
     this.player = player;
     this.type = type; // 1,2,3
@@ -95,6 +95,19 @@ export class Rabbit {
     this.healthBar.appendChild(this.healthFill);
     this.healthBar.appendChild(this.healthLabel);
     document.body.appendChild(this.healthBar);
+
+    // positional scream audio
+    if (listener) {
+      const loader = new THREE.AudioLoader();
+      this.screamSound = new THREE.PositionalAudio(listener);
+      loader.load('audio/scream.wav', (buffer) => {
+        this.screamSound.setBuffer(buffer);
+        this.screamSound.setRefDistance(5);
+        this.screamSound.setLoop(false);
+      });
+      this.mesh.add(this.screamSound);
+    }
+    this.lastScream = 0;
   }
 
   startNight() {
@@ -155,6 +168,11 @@ export class Rabbit {
           this.endNight();
         }
       } else if (this.isDragging) {
+        const now = performance.now();
+        if (isNight && this.screamSound && now - this.lastScream > 3000) {
+          if (!this.screamSound.isPlaying) this.screamSound.play();
+          this.lastScream = now;
+        }
         const dir = this.home.clone().sub(this.player.position).setY(0).normalize();
         this.player.position.addScaledVector(dir, 2 * dt);
         this.mesh.position.copy(this.player.position);


### PR DESCRIPTION
## Summary
- Play looping horror drone at night and stop at dawn
- Give rabbits positional scream sound triggered while attacking
- Wire rabbits to audio listener for proximity-based volume

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7618cf2e4832185f9d66c8dcc91e8