### PR TITLE
Add house health and resilient rabbit bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,8 +64,9 @@
     }
     .rabbit-health {
       position: fixed;
-      width: 60px;
-      height: 8px;
+      transform: translate(-50%, -50%);
+      width: 120px;
+      height: 12px;
       background: rgba(80,0,0,0.8);
       border: 1px solid #300;
       pointer-events: none;
@@ -76,6 +77,28 @@
       width: 100%;
     }
     .rabbit-health .label {
+      position: absolute;
+      top: -18px;
+      left: 50%;
+      transform: translateX(-50%);
+      color: #fff;
+      font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    }
+    .house-health {
+      position: fixed;
+      transform: translate(-50%, -50%);
+      width: 80px;
+      height: 6px;
+      background: rgba(80,0,0,0.8);
+      border: 1px solid #300;
+      pointer-events: none;
+    }
+    .house-health .fill {
+      background: #3498db;
+      height: 100%;
+      width: 100%;
+    }
+    .house-health .label {
       position: absolute;
       top: -14px;
       left: 50%;

--- a/js/game.js
+++ b/js/game.js
@@ -283,20 +283,32 @@ function update(dt){
     }
     if (b.mesh.position.length() > groundSize) {
       scene.remove(b.mesh); balls.splice(i,1);
+      continue;
     }
-    // collision with rabbits
+    const radius = BALL_RADIUS * b.mesh.scale.x;
+    let removed = false;
     for (const r of rabbits) {
-      if (!r.visible) continue;
-      const radius = BALL_RADIUS * b.mesh.scale.x;
-      if (r.mesh.position.distanceTo(b.mesh.position) < radius + 1) {
-        r.hitByBall();
+      if (!r.houseDestroyed && r.house.position.distanceTo(b.mesh.position) < radius + 2.5) {
+        r.damageHouse();
         scene.remove(b.mesh); balls.splice(i,1);
+        removed = true;
         break;
       }
     }
+    if (removed) continue;
+    for (const r of rabbits) {
+      if (!r.visible) continue;
+      if (r.mesh.position.distanceTo(b.mesh.position) < radius + 1) {
+        r.hitByBall();
+        scene.remove(b.mesh); balls.splice(i,1);
+        removed = true;
+        break;
+      }
+    }
+    if (removed) continue;
   }
 
-  // Bullets update and collision with balls
+  // Bullets update and collision
   for (let i=bullets.length-1;i>=0;i--){
     const b = bullets[i];
     b.mesh.position.addScaledVector(b.vel, dt);
@@ -305,6 +317,16 @@ function update(dt){
     if (life > 1 || b.mesh.position.length() > groundSize) {
       scene.remove(b.mesh); bullets.splice(i,1); continue;
     }
+    let removed = false;
+    for (const r of rabbits) {
+      if (!r.houseDestroyed && r.house.position.distanceTo(b.mesh.position) < 2.5) {
+        r.damageHouse();
+        scene.remove(b.mesh); bullets.splice(i,1);
+        removed = true;
+        break;
+      }
+    }
+    if (removed) continue;
     for (let j = balls.length - 1; j >= 0; j--) {
       const ball = balls[j];
       const radius = BALL_RADIUS * ball.mesh.scale.x;
@@ -314,6 +336,7 @@ function update(dt){
         if (ball.mesh.scale.x < 0.2) {
           scene.remove(ball.mesh); balls.splice(j,1);
         }
+        removed = true;
         break;
       }
     }

--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -66,7 +66,7 @@ export class Rabbit {
     this.mesh = makeRabbit();
     this.visible = false;
 
-    this.maxHealth = 500;
+    this.maxHealth = 1000;
     this.health = this.maxHealth;
     this.immune = type === 2; // survives one hit
     this.isDragging = false; // for type 3
@@ -82,6 +82,20 @@ export class Rabbit {
     else this.house = createCave();
     this.house.position.copy(this.home);
     scene.add(this.house);
+
+    this.houseMaxHealth = 100;
+    this.houseHealth = this.houseMaxHealth;
+    this.houseDestroyed = false;
+
+    this.houseBar = document.createElement('div');
+    this.houseBar.className = 'house-health';
+    this.houseFill = document.createElement('div');
+    this.houseFill.className = 'fill';
+    this.houseLabel = document.createElement('div');
+    this.houseLabel.className = 'label';
+    this.houseBar.appendChild(this.houseFill);
+    this.houseBar.appendChild(this.houseLabel);
+    document.body.appendChild(this.houseBar);
 
     this.mesh.position.copy(this.home.clone().add(new THREE.Vector3(0, 0, 2)));
 
@@ -124,9 +138,16 @@ export class Rabbit {
     }
   }
 
-  hitByBall(amount = 10) {
+  hitByBall(amount = 5) {
     if (this.immune) { this.immune = false; return; }
     this.damage(amount);
+  }
+
+  damageHouse() {
+    if (this.houseDestroyed) return;
+    this.houseHealth = 0;
+    this.scene.remove(this.house);
+    this.houseDestroyed = true;
   }
 
   kick() {
@@ -138,6 +159,7 @@ export class Rabbit {
 
   update(dt, isNight, camera) {
     if (isNight) this.startNight(); else this.endNight();
+    this.updateHouse(dt, camera);
     if (!this.visible) {
       this.updateHealthBar(camera);
       return;
@@ -193,10 +215,37 @@ export class Rabbit {
     pos.project(camera);
     const x = (pos.x * 0.5 + 0.5) * innerWidth;
     const y = (-pos.y * 0.5 + 0.5) * innerHeight;
-    this.healthBar.style.transform = `translate(-50%, -50%) translate(${x}px, ${y}px)`;
+    this.healthBar.style.left = `${x}px`;
+    this.healthBar.style.top = `${y}px`;
     const pct = this.health / this.maxHealth;
     this.healthFill.style.width = `${pct * 100}%`;
     this.healthLabel.textContent = Math.round(this.health);
+  }
+
+  updateHouse(dt, camera) {
+    if (this.houseDestroyed) {
+      this.houseHealth = Math.min(this.houseMaxHealth, this.houseHealth + 20 * dt);
+      if (this.houseHealth >= this.houseMaxHealth) {
+        if (this.type === 1) this.house = createHouse();
+        else if (this.type === 2) this.house = createSheepHouse();
+        else this.house = createCave();
+        this.house.position.copy(this.home);
+        this.scene.add(this.house);
+        this.houseDestroyed = false;
+      }
+    }
+    const pos = this.houseDestroyed ? this.home : this.house.position;
+    this.houseBar.style.display = 'block';
+    const p = pos.clone();
+    p.y += 3;
+    p.project(camera);
+    const x = (p.x * 0.5 + 0.5) * innerWidth;
+    const y = (-p.y * 0.5 + 0.5) * innerHeight;
+    this.houseBar.style.left = `${x}px`;
+    this.houseBar.style.top = `${y}px`;
+    const pct = this.houseHealth / this.houseMaxHealth;
+    this.houseFill.style.width = `${pct * 100}%`;
+    this.houseLabel.textContent = Math.round(this.houseHealth);
   }
 }
 


### PR DESCRIPTION
## Summary
- Enlarge rabbit health bars and add dedicated house health bars
- Track rabbit and house health, with auto-repairing houses destroyed on any hit
- Allow balls and player bullets to damage houses, and show health values on HUD

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7623c294c8321aa7904d8d3591d9c