### PR TITLE
Add destructible rabbit houses with repair and improved health UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,10 @@
       user-select: none;
     }
     .rabbit-health {
-      position: fixed;
-      width: 60px;
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 120px;
       height: 8px;
       background: rgba(80,0,0,0.8);
       border: 1px solid #300;
@@ -82,6 +84,30 @@
       transform: translateX(-50%);
       color: #fff;
       font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    }
+
+    .house-health {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 80px;
+      height: 6px;
+      background: rgba(80,80,80,0.8);
+      border: 1px solid #333;
+      pointer-events: none;
+    }
+    .house-health .fill {
+      background: #3498db;
+      height: 100%;
+      width: 100%;
+    }
+    .house-health .label {
+      position: absolute;
+      top: -12px;
+      left: 50%;
+      transform: translateX(-50%);
+      color: #fff;
+      font: 11px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     }
   </style>
 </head>

--- a/js/game.js
+++ b/js/game.js
@@ -284,19 +284,26 @@ function update(dt){
     if (b.mesh.position.length() > groundSize) {
       scene.remove(b.mesh); balls.splice(i,1);
     }
-    // collision with rabbits
+    // collision with rabbits or houses
+    const radius = BALL_RADIUS * b.mesh.scale.x;
+    let hit = false;
     for (const r of rabbits) {
-      if (!r.visible) continue;
-      const radius = BALL_RADIUS * b.mesh.scale.x;
-      if (r.mesh.position.distanceTo(b.mesh.position) < radius + 1) {
+      if (!hit && r.visible && r.mesh.position.distanceTo(b.mesh.position) < radius + 1) {
         r.hitByBall();
+        hit = true;
+      }
+      if (!hit && !r.houseDestroyed && r.house.position.distanceTo(b.mesh.position) < radius + 2) {
+        r.damageHouse();
+        hit = true;
+      }
+      if (hit) {
         scene.remove(b.mesh); balls.splice(i,1);
         break;
       }
     }
   }
 
-  // Bullets update and collision with balls
+  // Bullets update and collision with balls/rabbits/houses
   for (let i=bullets.length-1;i>=0;i--){
     const b = bullets[i];
     b.mesh.position.addScaledVector(b.vel, dt);
@@ -305,17 +312,34 @@ function update(dt){
     if (life > 1 || b.mesh.position.length() > groundSize) {
       scene.remove(b.mesh); bullets.splice(i,1); continue;
     }
+    let hit = false;
     for (let j = balls.length - 1; j >= 0; j--) {
       const ball = balls[j];
       const radius = BALL_RADIUS * ball.mesh.scale.x;
       if (b.mesh.position.distanceTo(ball.mesh.position) < radius + 0.1) {
         ball.mesh.scale.multiplyScalar(0.7);
-        scene.remove(b.mesh); bullets.splice(i,1);
+        hit = true;
         if (ball.mesh.scale.x < 0.2) {
           scene.remove(ball.mesh); balls.splice(j,1);
         }
         break;
       }
+    }
+    if (!hit) {
+      for (const r of rabbits) {
+        if (!hit && r.visible && b.mesh.position.distanceTo(r.mesh.position) < 1) {
+          r.damage(5);
+          hit = true;
+        }
+        if (!hit && !r.houseDestroyed && b.mesh.position.distanceTo(r.house.position) < 2) {
+          r.damageHouse();
+          hit = true;
+        }
+        if (hit) break;
+      }
+    }
+    if (hit) {
+      scene.remove(b.mesh); bullets.splice(i,1);
     }
   }
 
@@ -345,6 +369,10 @@ addEventListener('resize', ()=>{
   camera.aspect = innerWidth/innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(innerWidth, innerHeight);
+  for (const r of rabbits) {
+    r.updateHealthBar(camera);
+    r.updateHouseBar(camera);
+  }
 });
 
 animate();

--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -66,7 +66,7 @@ export class Rabbit {
     this.mesh = makeRabbit();
     this.visible = false;
 
-    this.maxHealth = 500;
+    this.maxHealth = 500; // about five nights of damage
     this.health = this.maxHealth;
     this.immune = type === 2; // survives one hit
     this.isDragging = false; // for type 3
@@ -83,9 +83,30 @@ export class Rabbit {
     this.house.position.copy(this.home);
     scene.add(this.house);
 
+    // house health
+    this.houseMaxHealth = 1;
+    this.houseHealth = this.houseMaxHealth;
+    this.houseRepairRate = 0.25; // per second
+    this.houseDestroyed = false;
+
+    // house health bar
+    this.houseBarWidth = 80;
+    this.houseBarHeight = 6;
+    this.houseBar = document.createElement('div');
+    this.houseBar.className = 'house-health';
+    this.houseFill = document.createElement('div');
+    this.houseFill.className = 'fill';
+    this.houseLabel = document.createElement('div');
+    this.houseLabel.className = 'label';
+    this.houseBar.appendChild(this.houseFill);
+    this.houseBar.appendChild(this.houseLabel);
+    document.body.appendChild(this.houseBar);
+
     this.mesh.position.copy(this.home.clone().add(new THREE.Vector3(0, 0, 2)));
 
-    // health bar UI
+    // rabbit health bar UI
+    this.healthBarWidth = 120;
+    this.healthBarHeight = 8;
     this.healthBar = document.createElement('div');
     this.healthBar.className = 'rabbit-health';
     this.healthFill = document.createElement('div');
@@ -124,6 +145,13 @@ export class Rabbit {
     }
   }
 
+  damageHouse() {
+    if (this.houseDestroyed) return;
+    this.houseHealth = 0;
+    this.scene.remove(this.house);
+    this.houseDestroyed = true;
+  }
+
   hitByBall(amount = 10) {
     if (this.immune) { this.immune = false; return; }
     this.damage(amount);
@@ -137,9 +165,19 @@ export class Rabbit {
   }
 
   update(dt, isNight, camera) {
+    // repair house over time
+    if (this.houseHealth < this.houseMaxHealth) {
+      this.houseHealth = Math.min(this.houseMaxHealth, this.houseHealth + this.houseRepairRate * dt);
+      if (this.houseDestroyed && this.houseHealth >= this.houseMaxHealth) {
+        this.scene.add(this.house);
+        this.houseDestroyed = false;
+      }
+    }
+
     if (isNight) this.startNight(); else this.endNight();
     if (!this.visible) {
       this.updateHealthBar(camera);
+      this.updateHouseBar(camera);
       return;
     }
 
@@ -182,6 +220,7 @@ export class Rabbit {
     }
 
     this.updateHealthBar(camera);
+    this.updateHouseBar(camera);
   }
 
   updateHealthBar(camera) {
@@ -191,12 +230,26 @@ export class Rabbit {
     const pos = this.mesh.position.clone();
     pos.y += 3;
     pos.project(camera);
-    const x = (pos.x * 0.5 + 0.5) * innerWidth;
-    const y = (-pos.y * 0.5 + 0.5) * innerHeight;
-    this.healthBar.style.transform = `translate(-50%, -50%) translate(${x}px, ${y}px)`;
+    const x = (pos.x * 0.5 + 0.5) * innerWidth - this.healthBarWidth / 2;
+    const y = (-pos.y * 0.5 + 0.5) * innerHeight - this.healthBarHeight / 2;
+    this.healthBar.style.left = `${x}px`;
+    this.healthBar.style.top = `${y}px`;
     const pct = this.health / this.maxHealth;
     this.healthFill.style.width = `${pct * 100}%`;
     this.healthLabel.textContent = Math.round(this.health);
+  }
+
+  updateHouseBar(camera) {
+    const pos = this.home.clone();
+    pos.y += 3;
+    pos.project(camera);
+    const x = (pos.x * 0.5 + 0.5) * innerWidth - this.houseBarWidth / 2;
+    const y = (-pos.y * 0.5 + 0.5) * innerHeight - this.houseBarHeight / 2;
+    this.houseBar.style.left = `${x}px`;
+    this.houseBar.style.top = `${y}px`;
+    const pct = this.houseHealth / this.houseMaxHealth;
+    this.houseFill.style.width = `${pct * 100}%`;
+    this.houseLabel.textContent = Math.round(pct * 100);
   }
 }
 


### PR DESCRIPTION
## Summary
- Enlarge rabbit health bars and add house health UI
- Implement house destruction, repair mechanics, and collision damage from balls and bullets
- Keep health bars aligned on resize to avoid misplacement

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7623c294c8321aa7904d8d3591d9c