### PR TITLE
Add house health and robust health bars for rabbits

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,11 +64,12 @@
     }
     .rabbit-health {
       position: fixed;
-      width: 60px;
-      height: 8px;
+      width: 120px;
+      height: 12px;
       background: rgba(80,0,0,0.8);
       border: 1px solid #300;
       pointer-events: none;
+      transform: translate(-50%, -100%);
     }
     .rabbit-health .fill {
       background: #2ecc71;
@@ -76,6 +77,28 @@
       width: 100%;
     }
     .rabbit-health .label {
+      position: absolute;
+      top: -18px;
+      left: 50%;
+      transform: translateX(-50%);
+      color: #fff;
+      font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    }
+    .house-health {
+      position: fixed;
+      width: 80px;
+      height: 8px;
+      background: rgba(80,80,0,0.8);
+      border: 1px solid #330;
+      pointer-events: none;
+      transform: translate(-50%, -100%);
+    }
+    .house-health .fill {
+      background: #f1c40f;
+      height: 100%;
+      width: 100%;
+    }
+    .house-health .label {
       position: absolute;
       top: -14px;
       left: 50%;

--- a/js/game.js
+++ b/js/game.js
@@ -283,20 +283,30 @@ function update(dt){
     }
     if (b.mesh.position.length() > groundSize) {
       scene.remove(b.mesh); balls.splice(i,1);
+      continue;
     }
-    // collision with rabbits
+    const radius = BALL_RADIUS * b.mesh.scale.x;
+    let hit = false;
+    // collision with houses and rabbits
     for (const r of rabbits) {
+      if (r.houseHealth > 0 && r.house.position.distanceTo(b.mesh.position) < radius + 2) {
+        r.damageHouse();
+        hit = true;
+        break;
+      }
       if (!r.visible) continue;
-      const radius = BALL_RADIUS * b.mesh.scale.x;
       if (r.mesh.position.distanceTo(b.mesh.position) < radius + 1) {
         r.hitByBall();
-        scene.remove(b.mesh); balls.splice(i,1);
+        hit = true;
         break;
       }
     }
+    if (hit) {
+      scene.remove(b.mesh); balls.splice(i,1);
+    }
   }
 
-  // Bullets update and collision with balls
+  // Bullets update and collision with objects
   for (let i=bullets.length-1;i>=0;i--){
     const b = bullets[i];
     b.mesh.position.addScaledVector(b.vel, dt);
@@ -305,18 +315,33 @@ function update(dt){
     if (life > 1 || b.mesh.position.length() > groundSize) {
       scene.remove(b.mesh); bullets.splice(i,1); continue;
     }
+    let hit = false;
     for (let j = balls.length - 1; j >= 0; j--) {
       const ball = balls[j];
       const radius = BALL_RADIUS * ball.mesh.scale.x;
       if (b.mesh.position.distanceTo(ball.mesh.position) < radius + 0.1) {
         ball.mesh.scale.multiplyScalar(0.7);
-        scene.remove(b.mesh); bullets.splice(i,1);
+        hit = true;
         if (ball.mesh.scale.x < 0.2) {
           scene.remove(ball.mesh); balls.splice(j,1);
         }
         break;
       }
     }
+    if (hit) { scene.remove(b.mesh); bullets.splice(i,1); continue; }
+    for (const r of rabbits) {
+      if (r.houseHealth > 0 && b.mesh.position.distanceTo(r.house.position) < 2.5) {
+        r.damageHouse();
+        hit = true;
+        break;
+      }
+      if (r.visible && b.mesh.position.distanceTo(r.mesh.position) < 1) {
+        r.damage(25);
+        hit = true;
+        break;
+      }
+    }
+    if (hit) { scene.remove(b.mesh); bullets.splice(i,1); }
   }
 
   for (const r of rabbits) {


### PR DESCRIPTION
## Summary
- Enlarge rabbit health bars with numeric labels and add dedicated health bars for rabbit houses
- Track house health: houses break from any hit, rabbits auto-repair them, and bullets/balls can destroy them
- Refine health bar positioning to stay aligned with rabbits and houses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7623c294c8321aa7904d8d3591d9c