### PR TITLE
feat: add aiming down sights

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,11 @@
     }
     .ui b { color: #fff; }
     .crosshair {
-      position: fixed; left: 50%; top: 50%; transform: translate(-50%, -50%);
+      position: fixed; left: 50%; top: 50%; transform: translate(-50%, -50%) scale(1);
       width: 14px; height: 14px; pointer-events: none; opacity: 0.85;
+      transition: transform 0.1s;
     }
+    .crosshair.aiming { transform: translate(-50%, -50%) scale(0.7); }
     .crosshair:before, .crosshair:after {
       content: ""; position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
       background: #e9eef5; border-radius: 2px;

--- a/js/controls.js
+++ b/js/controls.js
@@ -2,7 +2,8 @@ export const controls = {
   yaw: 0,
   pitch: 0,
   keys: new Set(),
-  pointerLocked: false
+  pointerLocked: false,
+  aiming: false
 };
 
 export function initControls(domElement, shoot) {
@@ -24,8 +25,16 @@ export function initControls(domElement, shoot) {
       e.preventDefault();
     } else if (e.button === 0) {
       shoot();
+    } else if (e.button === 2) {
+      controls.aiming = true;
     }
   });
+
+  addEventListener('mouseup', e => {
+    if (e.button === 2) controls.aiming = false;
+  });
+
+  addEventListener('contextmenu', e => e.preventDefault());
 
   document.addEventListener('pointerlockchange', () => {
     controls.pointerLocked = document.pointerLockElement === domElement;

--- a/js/game.js
+++ b/js/game.js
@@ -26,7 +26,9 @@ scene.background = new THREE.Color(0x7fb0ff);
 scene.fog = new THREE.Fog(0x7fb0ff, 20, 140);
 
 // --- Camera (third‑person follow) ---
-const camera = new THREE.PerspectiveCamera(70, innerWidth/innerHeight, 0.1, 500);
+const FOV_NORMAL = 70;
+const FOV_AIM = 45;
+const camera = new THREE.PerspectiveCamera(FOV_NORMAL, innerWidth/innerHeight, 0.1, 500);
 
 // --- Lights ---
 const hemi = new THREE.HemisphereLight(0xffffff, 0x335533, 0.6);
@@ -152,6 +154,8 @@ controls.trappedUntil = 0;
 
 // Camera offset relative to player in local space (over‑the‑shoulder)
 const camOffset = new THREE.Vector3(1.6, 1.8, 3.8); // right shoulder & back
+const aimCamOffset = new THREE.Vector3(0.3, 1.6, 1.2); // closer when aiming
+const crosshair = document.querySelector('.crosshair');
 
 // --- Bullets ---
 const bullets = [];
@@ -251,11 +255,16 @@ function update(dt){
 
   // Update camera to orbit around player
     const camRot = new THREE.Euler(pitch, yaw, 0, 'YXZ');
-    const offsetWorld = camOffset.clone().applyEuler(camRot);
+    const offset = controls.aiming ? aimCamOffset : camOffset;
+    const offsetWorld = offset.clone().applyEuler(camRot);
     const camPos = player.position.clone().add(offsetWorld);
     camera.position.lerp(camPos, 0.85);
     const camQuat = new THREE.Quaternion().setFromEuler(camRot);
     camera.quaternion.slerp(camQuat, 0.85);
+    const targetFov = controls.aiming ? FOV_AIM : FOV_NORMAL;
+    camera.fov += (targetFov - camera.fov) * 0.1;
+    camera.updateProjectionMatrix();
+    crosshair.classList.toggle('aiming', controls.aiming);
 
   // Spawn balls from dispensers
   for (const d of dispensers) {


### PR DESCRIPTION
## Summary
- allow right mouse to toggle aiming mode and zoom the camera
- shrink crosshair while aiming for better Fortnite-like shooting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7669095608321b4e9597da518b410