### PR TITLE
Add right-click aiming mode

### DIFF
--- a/js/controls.js
+++ b/js/controls.js
@@ -2,7 +2,8 @@ export const controls = {
   yaw: 0,
   pitch: 0,
   keys: new Set(),
-  pointerLocked: false
+  pointerLocked: false,
+  aiming: false
 };
 
 export function initControls(domElement, shoot) {
@@ -24,8 +25,16 @@ export function initControls(domElement, shoot) {
       e.preventDefault();
     } else if (e.button === 0) {
       shoot();
+    } else if (e.button === 2) {
+      controls.aiming = true;
     }
   });
+
+  addEventListener('mouseup', e => {
+    if (e.button === 2) controls.aiming = false;
+  });
+
+  addEventListener('contextmenu', e => e.preventDefault());
 
   document.addEventListener('pointerlockchange', () => {
     controls.pointerLocked = document.pointerLockElement === domElement;

--- a/js/game.js
+++ b/js/game.js
@@ -150,8 +150,9 @@ const rabbits = [
 const dayNight = new DayNightCycle(scene, sun, hemi);
 controls.trappedUntil = 0;
 
-// Camera offset relative to player in local space (over‑the‑shoulder)
+// Camera offsets (default over‑the‑shoulder vs. aiming)
 const camOffset = new THREE.Vector3(1.6, 1.8, 3.8); // right shoulder & back
+const camAimOffset = new THREE.Vector3(0.4, 1.6, 2.5); // closer when aiming
 
 // --- Bullets ---
 const bullets = [];
@@ -250,12 +251,16 @@ function update(dt){
   armR.rotation.x = pitch * 0.75;
 
   // Update camera to orbit around player
-    const camRot = new THREE.Euler(pitch, yaw, 0, 'YXZ');
-    const offsetWorld = camOffset.clone().applyEuler(camRot);
-    const camPos = player.position.clone().add(offsetWorld);
-    camera.position.lerp(camPos, 0.85);
-    const camQuat = new THREE.Quaternion().setFromEuler(camRot);
-    camera.quaternion.slerp(camQuat, 0.85);
+  const camRot = new THREE.Euler(pitch, yaw, 0, 'YXZ');
+  const targetOffset = controls.aiming ? camAimOffset : camOffset;
+  const offsetWorld = targetOffset.clone().applyEuler(camRot);
+  const camPos = player.position.clone().add(offsetWorld);
+  camera.position.lerp(camPos, 0.85);
+  const camQuat = new THREE.Quaternion().setFromEuler(camRot);
+  camera.quaternion.slerp(camQuat, 0.85);
+  const targetFov = controls.aiming ? 45 : 70;
+  camera.fov += (targetFov - camera.fov) * 0.1;
+  camera.updateProjectionMatrix();
 
   // Spawn balls from dispensers
   for (const d of dispensers) {


### PR DESCRIPTION
## Summary
- Allow holding right mouse to enter aiming mode and prevent context menu.
- Zoom and reposition camera for tighter shots while aiming.

## Testing
- `node --check js/game.js && node --check js/controls.js`

------
https://chatgpt.com/codex/tasks/task_e_68c7669095608321b4e9597da518b410