### PR TITLE
Add right-click aiming down sights

### DIFF
--- a/js/controls.js
+++ b/js/controls.js
@@ -2,7 +2,8 @@ export const controls = {
   yaw: 0,
   pitch: 0,
   keys: new Set(),
-  pointerLocked: false
+  pointerLocked: false,
+  aiming: false
 };
 
 export function initControls(domElement, shoot) {
@@ -18,18 +19,31 @@ export function initControls(domElement, shoot) {
     controls.keys.delete(e.code);
   });
 
+  domElement.addEventListener('contextmenu', e => e.preventDefault());
+
   addEventListener('mousedown', e => {
     if (!controls.pointerLocked) {
       domElement.requestPointerLock();
       e.preventDefault();
     } else if (e.button === 0) {
       shoot();
+    } else if (e.button === 2) {
+      controls.aiming = true;
+    }
+  });
+
+  addEventListener('mouseup', e => {
+    if (e.button === 2) {
+      controls.aiming = false;
     }
   });
 
   document.addEventListener('pointerlockchange', () => {
     controls.pointerLocked = document.pointerLockElement === domElement;
     hint.classList.toggle('hidden', controls.pointerLocked);
+    if (!controls.pointerLocked) {
+      controls.aiming = false;
+    }
   });
 
   addEventListener('mousemove', e => {

--- a/js/game.js
+++ b/js/game.js
@@ -150,8 +150,13 @@ const rabbits = [
 const dayNight = new DayNightCycle(scene, sun, hemi);
 controls.trappedUntil = 0;
 
-// Camera offset relative to player in local space (over‑the‑shoulder)
-const camOffset = new THREE.Vector3(1.6, 1.8, 3.8); // right shoulder & back
+// Camera offsets for hip fire vs. aiming
+const camOffsetHip = new THREE.Vector3(1.6, 1.8, 3.8); // right shoulder & back
+const camOffsetAim = new THREE.Vector3(0.4, 1.6, 2.0); // closer when aiming
+const camOffset = camOffsetHip.clone();
+const defaultFov = 70;
+const aimFov = 55;
+camera.fov = defaultFov;
 
 // --- Bullets ---
 const bullets = [];
@@ -250,6 +255,11 @@ function update(dt){
   armR.rotation.x = pitch * 0.75;
 
   // Update camera to orbit around player
+    const targetOffset = controls.aiming ? camOffsetAim : camOffsetHip;
+    camOffset.lerp(targetOffset, 0.1);
+    const targetFov = controls.aiming ? aimFov : defaultFov;
+    camera.fov = THREE.MathUtils.lerp(camera.fov, targetFov, 0.1);
+    camera.updateProjectionMatrix();
     const camRot = new THREE.Euler(pitch, yaw, 0, 'YXZ');
     const offsetWorld = camOffset.clone().applyEuler(camRot);
     const camPos = player.position.clone().add(offsetWorld);
@@ -337,7 +347,10 @@ function animate(){
 
 // Spawn position and initial camera placement
   player.position.set(0,0,8);
+  camOffset.copy(camOffsetHip);
   camera.position.copy(player.position).add(camOffset);
+  camera.fov = defaultFov;
+  camera.updateProjectionMatrix();
   camera.quaternion.setFromEuler(new THREE.Euler(0,0,0));
 
 // Resize


### PR DESCRIPTION
## Summary
- enable right mouse button to enter aiming mode
- adjust camera offset and FOV when aiming for Fortnite-style targeting

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c765e503988321be3de1bbafd90e4f