### PR TITLE
Align bullet raycast horizontally with camera

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -205,7 +205,8 @@ function shootBullet(){
     hitPoint = raycaster.ray.at(100, new THREE.Vector3());
   }
 
-  // Aim from the muzzle toward the raycast point so bullets pass through the crosshair
+  // Only match the horizontal aim to the camera; keep the muzzle's height
+  hitPoint.y = muzzleWorld.y;
   const dir = hitPoint.clone().sub(muzzleWorld).normalize();
 
   const mesh = new THREE.Mesh(bulletGeo, bulletMat);


### PR DESCRIPTION
## Summary
- align bullet shooting raycast to camera yaw for accurate side-to-side aiming

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c76bd1cd8c8321bdb963cccd4c5416