### PR TITLE
Add settings menu with audio and combat tuning sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,37 @@
       color: #fff;
       font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     }
+
+    .settings-overlay {
+      position: fixed; inset: 0;
+      background: rgba(0,0,0,0.6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .settings-overlay.hidden { display: none; }
+    .settings-menu {
+      background: rgba(20,22,24,0.85);
+      padding: 20px; border-radius: 14px;
+      width: 320px;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.35);
+      backdrop-filter: blur(6px);
+      color: #e9eef5;
+      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    }
+    .settings-menu h2 { margin-top: 0; text-align: center; }
+    .settings-menu .setting {
+      margin: 12px 0; display: flex; align-items: center;
+    }
+    .settings-menu .setting label { flex: 1; }
+    .settings-menu .setting input[type=range] { width: 160px; margin-left: 8px; }
+    .settings-menu .setting span.value { width: 40px; text-align: right; margin-left: 8px; }
+    .settings-menu .actions { text-align: center; margin-top: 16px; }
+    .settings-menu button {
+      padding: 6px 12px; border: none; border-radius: 6px;
+      background: #3b82f6; color: #fff; cursor: pointer;
+    }
+    .settings-menu button:hover { background: #2563eb; }
   </style>
 </head>
 <body>
@@ -90,7 +121,43 @@
   <div class="crosshair"></div>
     <div class="hint" id="hint">Click to lock the mouse (<b>Esc</b> to release). <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
   <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
-  <div class="panel">Balls: <input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
+
+  <div id="settingsOverlay" class="settings-overlay hidden">
+    <div class="settings-menu">
+      <h2>Settings</h2>
+      <div class="setting">
+        <label for="ballSlider">Balls</label>
+        <input type="range" id="ballSlider" min="100" max="10000" value="2000" />
+        <span class="value" id="ballCountLabel">2000</span>
+      </div>
+      <div class="setting">
+        <label for="volumeSlider">Volume</label>
+        <input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" />
+        <span class="value" id="volumeValue">50</span>
+      </div>
+      <div class="setting">
+        <label for="faceSlider">Face Offset</label>
+        <input type="range" id="faceSlider" min="-1" max="2" step="0.01" value="0" />
+        <span class="value" id="faceValue">0.00</span>
+      </div>
+      <div class="setting">
+        <label for="rabbitHealthSlider">Rabbit Max Health</label>
+        <input type="range" id="rabbitHealthSlider" min="100" max="1000" step="10" value="500" />
+        <span class="value" id="rabbitHealthLabel">500</span>
+      </div>
+      <div class="setting">
+        <label for="bulletDamageSlider">Bullet Damage</label>
+        <input type="range" id="bulletDamageSlider" min="1" max="500" value="50" />
+        <span class="value" id="bulletDamageLabel">50</span>
+      </div>
+      <div class="setting">
+        <label for="ballDamageSlider">Ball Damage</label>
+        <input type="range" id="ballDamageSlider" min="1" max="100" value="10" />
+        <span class="value" id="ballDamageLabel">10</span>
+      </div>
+      <div class="actions"><button id="resumeBtn">Resume</button></div>
+    </div>
+  </div>
 
   <script type="module" src="js/main.js"></script>
 </body>

--- a/js/controls.js
+++ b/js/controls.js
@@ -5,7 +5,7 @@ export const controls = {
   pointerLocked: false
 };
 
-export function initControls(domElement, shoot) {
+export function initControls(domElement, shoot, onPointerLockChange) {
   const hint = document.getElementById('hint');
   addEventListener('keydown', e => {
     if (e.code === 'Escape' && controls.pointerLocked) {
@@ -30,6 +30,7 @@ export function initControls(domElement, shoot) {
   document.addEventListener('pointerlockchange', () => {
     controls.pointerLocked = document.pointerLockElement === domElement;
     hint.classList.toggle('hidden', controls.pointerLocked);
+    if (onPointerLockChange) onPointerLockChange(controls.pointerLocked);
   });
 
   addEventListener('mousemove', e => {

--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -96,7 +96,8 @@ export class Rabbit {
     this.scene.add(this.face);
     this.face.visible = false;
     this.headOffset = new THREE.Vector3(0, 2.1, 0);
-    this.headRadius = headRadius + 0.01;
+    this.baseHeadRadius = headRadius + 0.01;
+    this.faceOffset = 0;
 
     // health bar UI
     this.healthBar = document.createElement('div');
@@ -199,7 +200,7 @@ export class Rabbit {
       if (this.face.visible) {
         const headPos = this.mesh.localToWorld(this.headOffset.clone());
         const dir = this.player.position.clone().sub(headPos).normalize();
-        this.face.position.copy(headPos.clone().addScaledVector(dir, this.headRadius));
+        this.face.position.copy(headPos.clone().addScaledVector(dir, this.baseHeadRadius + this.faceOffset));
         this.face.lookAt(this.player.position);
       }
     }


### PR DESCRIPTION
## Summary
- Add full-screen settings overlay with sliders for ball count, volume, face offset, rabbit health, bullet damage, and ball damage.
- Notify game of pointer lock changes to show menu and start background audio.
- Enable adjustable bullet and ball damage and avoid face clipping on rabbits.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c775ac33408321b10408b6a3817407