### PR TITLE
feat: add settings menu with gameplay sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,16 +35,17 @@
       text-align: center;
     }
     .hidden { display: none; }
-
-    .panel {
-      position: fixed; top: 16px; left: 16px;
-      padding: 10px 14px; border-radius: 14px;
-      background: rgba(20,22,24,0.65); color: #e9eef5;
+    .settings {
+      position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
+      min-width: 300px; padding: 20px 24px; border-radius: 16px;
+      background: rgba(20,22,24,0.95); color: #e9eef5;
       font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
-      user-select: none;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.5); backdrop-filter: blur(8px);
+      pointer-events: auto;
     }
-    .panel input[type=range] { width: 160px; }
+    .settings h2 { margin: 0 0 12px; font-size: 18px; }
+    .settings .row { display: flex; align-items: center; justify-content: space-between; margin: 8px 0; }
+    .settings input[type=range] { width: 160px; margin-left: 8px; }
 
     .cycle-ui {
       position: fixed; top: 16px; right: 16px;
@@ -88,9 +89,17 @@
 <body>
   <div id="app"></div>
   <div class="crosshair"></div>
-    <div class="hint" id="hint">Click to lock the mouse (<b>Esc</b> to release). <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
+    <div class="hint" id="hint">Click to lock the mouse. Press <b>Esc</b> for settings. <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
   <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
-  <div class="panel">Balls: <input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
+  <div id="settingsMenu" class="settings hidden">
+    <h2>Settings</h2>
+    <div class="row">Balls: <input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
+    <div class="row">Volume: <input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /></div>
+    <div class="row">Face Offset: <input type="range" id="faceOffsetSlider" min="0" max="1" step="0.01" value="0.1" /></div>
+    <div class="row">Rabbit Max Health: <input type="range" id="rabbitHealthSlider" min="100" max="1000" step="10" value="500" /> <span id="rabbitHealthLabel">500</span></div>
+    <div class="row">Bullet Damage: <input type="range" id="bulletDamageSlider" min="10" max="200" step="5" value="50" /> <span id="bulletDamageLabel">50</span></div>
+    <div class="row">Ball Damage: <input type="range" id="ballDamageSlider" min="5" max="100" step="5" value="10" /> <span id="ballDamageLabel">10</span></div>
+  </div>
 
   <script type="module" src="js/main.js"></script>
 </body>

--- a/js/controls.js
+++ b/js/controls.js
@@ -5,11 +5,16 @@ export const controls = {
   pointerLocked: false
 };
 
-export function initControls(domElement, shoot) {
+export function initControls(domElement, shoot, toggleSettings) {
   const hint = document.getElementById('hint');
   addEventListener('keydown', e => {
-    if (e.code === 'Escape' && controls.pointerLocked) {
-      document.exitPointerLock();
+    if (e.code === 'Escape') {
+      if (controls.pointerLocked) {
+        document.exitPointerLock();
+        if (toggleSettings) toggleSettings(true);
+      } else if (toggleSettings) {
+        toggleSettings(false);
+      }
     } else {
       controls.keys.add(e.code);
     }

--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -97,6 +97,7 @@ function createCave() {
     this.face.visible = false;
     this.headOffset = new THREE.Vector3(0, 2.1, 0);
     this.headRadius = headRadius + 0.01;
+    this.faceOffset = 0.1;
 
     // health bar UI
     this.healthBar = document.createElement('div');
@@ -218,7 +219,7 @@ function createCave() {
       if (this.face.visible) {
         const headPos = this.mesh.localToWorld(this.headOffset.clone());
         const dir = this.player.position.clone().sub(headPos).normalize();
-        this.face.position.copy(headPos.clone().addScaledVector(dir, this.headRadius));
+        this.face.position.copy(headPos.clone().addScaledVector(dir, this.headRadius + this.faceOffset));
         this.face.lookAt(this.player.position);
       }
     }


### PR DESCRIPTION
## Summary
- Replace old panel with ESC-accessible settings menu
- Add sliders for audio volume, rabbit face offset, health, and damage tuning
- Bullets now damage rabbits and balls use configurable damage

## Testing
- `node --check js/game.js`
- `node --check js/controls.js`
- `node --check js/rabbit.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c777bddb148321ad7ed1e4542a3edd