### PR TITLE
Require resume button for settings menu and modularize settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
     <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="50" /> <span id="bulletDamageLabel">50</span></div>
     <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <span id="ballDamageLabel">10</span></div>
     <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
-    <p style="text-align:center;margin-top:12px;">Click the game to resume</p>
+    <button id="resumeButton" style="display:block;margin:12px auto 0 auto;">Resume</button>
   </div>
 
   <script type="module" src="js/main.js"></script>

--- a/js/controls.js
+++ b/js/controls.js
@@ -7,6 +7,7 @@ export const controls = {
 
 export function initControls(domElement, shoot, onPointerLockChange) {
   const hint = document.getElementById('hint');
+  const settingsEl = document.getElementById('settings');
   addEventListener('keydown', e => {
     if (e.code === 'Escape' && controls.pointerLocked) {
       document.exitPointerLock();
@@ -20,8 +21,10 @@ export function initControls(domElement, shoot, onPointerLockChange) {
 
   addEventListener('mousedown', e => {
     if (!controls.pointerLocked) {
-      domElement.requestPointerLock();
-      e.preventDefault();
+      if (e.target === domElement && settingsEl.classList.contains('hidden')) {
+        domElement.requestPointerLock();
+        e.preventDefault();
+      }
     } else if (e.button === 0) {
       shoot();
     }

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,7 @@
 import { controls, initControls } from "./controls.js";
 import { DayNightCycle } from './dayNight.js';
 import { Rabbit } from './rabbit.js';
+import { settings, settingsEl, initSettings } from './settings.js';
 import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
 export function startGame() {
 
@@ -12,52 +13,7 @@ renderer.setSize(innerWidth, innerHeight);
 renderer.shadowMap.enabled = true;
 app.appendChild(renderer.domElement);
 
-// UI controls
-const ballSlider = document.getElementById('ballSlider');
-const ballCountLabel = document.getElementById('ballCountLabel');
-const settings = document.getElementById('settings');
-const volumeSlider = document.getElementById('volumeSlider');
-const volumeLabel = document.getElementById('volumeLabel');
-const faceSlider = document.getElementById('faceSlider');
-const faceLabel = document.getElementById('faceLabel');
-const rabbitHealthSlider = document.getElementById('rabbitHealthSlider');
-const rabbitHealthLabel = document.getElementById('rabbitHealthLabel');
-const bulletDamageSlider = document.getElementById('bulletDamageSlider');
-const bulletDamageLabel = document.getElementById('bulletDamageLabel');
-const ballDamageSlider = document.getElementById('ballDamageSlider');
-const ballDamageLabel = document.getElementById('ballDamageLabel');
-
-let maxBalls = parseInt(ballSlider.value);
-ballSlider.addEventListener('input', () => {
-  ballCountLabel.textContent = ballSlider.value;
-  maxBalls = parseInt(ballSlider.value);
-});
-
-let bulletDamage = parseInt(bulletDamageSlider.value);
-bulletDamageSlider.addEventListener('input', () => {
-  bulletDamage = parseInt(bulletDamageSlider.value);
-  bulletDamageLabel.textContent = bulletDamage;
-});
-
-let ballDamage = parseInt(ballDamageSlider.value);
-ballDamageSlider.addEventListener('input', () => {
-  ballDamage = parseInt(ballDamageSlider.value);
-  ballDamageLabel.textContent = ballDamage;
-});
-
-Rabbit.faceOffset = parseFloat(faceSlider.value);
-faceSlider.addEventListener('input', () => {
-  const v = parseFloat(faceSlider.value);
-  faceLabel.textContent = v.toFixed(2);
-  Rabbit.faceOffset = v;
-});
-
-let rabbits = [];
-rabbitHealthSlider.addEventListener('input', () => {
-  const v = parseInt(rabbitHealthSlider.value);
-  rabbitHealthLabel.textContent = v;
-  for (const r of rabbits) { r.maxHealth = v; r.health = v; }
-});
+const rabbits = [];
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x7fb0ff);
@@ -75,12 +31,6 @@ scene.fog = new THREE.Fog(0x7fb0ff, 20, 140);
     nightSound.setBuffer(buffer);
     nightSound.setLoop(true);
     nightSound.setVolume(1.0);
-  });
-  listener.setMasterVolume(parseFloat(volumeSlider.value));
-  volumeSlider.addEventListener('input', () => {
-    const v = parseFloat(volumeSlider.value);
-    volumeLabel.textContent = v.toFixed(2);
-    listener.setMasterVolume(v);
   });
 
 // --- Lights ---
@@ -193,7 +143,7 @@ function updateHealthUI() {
 }
 
 // Rabbits and day/night cycle
-  rabbits = [
+  rabbits.push(
     new Rabbit(scene, player, 1, {
       onTrap: () => { controls.trappedUntil = performance.now() + 2000; }
     }, listener, audioLoader),
@@ -201,9 +151,10 @@ function updateHealthUI() {
     new Rabbit(scene, player, 3, {
       onAttack: () => { playerHealth *= 0.5; updateHealthUI(); }
     }, listener, audioLoader)
-  ];
-  const rabbitMax = parseInt(rabbitHealthSlider.value);
-  for (const r of rabbits) { r.maxHealth = rabbitMax; r.health = rabbitMax; }
+  );
+
+  initSettings(rabbits, listener, renderer.domElement);
+
 const dayNight = new DayNightCycle(scene, sun, hemi);
 controls.trappedUntil = 0;
 
@@ -281,7 +232,7 @@ function handleClick(){
   }
 }
 function onPointerLockChange(locked){
-  settings.classList.toggle('hidden', locked);
+  settingsEl.classList.toggle('hidden', locked);
 }
 initControls(renderer.domElement, handleClick, onPointerLockChange);
 
@@ -339,7 +290,7 @@ const GRAV = 22;
 
   // Spawn balls from dispensers
   for (const d of dispensers) {
-    if (totalDispensed >= maxBalls) break;
+    if (totalDispensed >= settings.maxBalls) break;
     if (now - d.last >= 1000) {
       const mesh = new THREE.Mesh(ballGeo, ballMat);
       mesh.position.copy(d.pos).add(new THREE.Vector3(0, BALL_RADIUS, 0));
@@ -369,7 +320,7 @@ const GRAV = 22;
       if (!r.visible) continue;
       const radius = BALL_RADIUS * b.mesh.scale.x;
       if (r.mesh.position.distanceTo(b.mesh.position) < radius + 1) {
-        r.hitByBall(ballDamage);
+        r.hitByBall(settings.ballDamage);
         scene.remove(b.mesh); balls.splice(i,1);
         break;
       }
@@ -401,7 +352,7 @@ const GRAV = 22;
     for (const r of rabbits) {
       if (!r.visible) continue;
       if (b.mesh.position.distanceTo(r.mesh.position) < 2) {
-        r.damage(bulletDamage);
+        r.damage(settings.bulletDamage);
         scene.remove(b.mesh); bullets.splice(i,1);
         break;
       }

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,72 @@
+import { Rabbit } from './rabbit.js';
+
+export const settingsEl = document.getElementById('settings');
+const ballSlider = document.getElementById('ballSlider');
+const ballCountLabel = document.getElementById('ballCountLabel');
+const volumeSlider = document.getElementById('volumeSlider');
+const volumeLabel = document.getElementById('volumeLabel');
+const faceSlider = document.getElementById('faceSlider');
+const faceLabel = document.getElementById('faceLabel');
+const rabbitHealthSlider = document.getElementById('rabbitHealthSlider');
+const rabbitHealthLabel = document.getElementById('rabbitHealthLabel');
+const bulletDamageSlider = document.getElementById('bulletDamageSlider');
+const bulletDamageLabel = document.getElementById('bulletDamageLabel');
+const ballDamageSlider = document.getElementById('ballDamageSlider');
+const ballDamageLabel = document.getElementById('ballDamageLabel');
+const resumeButton = document.getElementById('resumeButton');
+
+export const settings = {
+  maxBalls: parseInt(ballSlider.value),
+  bulletDamage: parseInt(bulletDamageSlider.value),
+  ballDamage: parseInt(ballDamageSlider.value)
+};
+
+export function initSettings(rabbits, listener, canvas) {
+  ballCountLabel.textContent = ballSlider.value;
+  bulletDamageLabel.textContent = settings.bulletDamage;
+  ballDamageLabel.textContent = settings.ballDamage;
+  volumeLabel.textContent = parseFloat(volumeSlider.value).toFixed(2);
+  faceLabel.textContent = parseFloat(faceSlider.value).toFixed(2);
+  rabbitHealthLabel.textContent = rabbitHealthSlider.value;
+
+  ballSlider.addEventListener('input', () => {
+    ballCountLabel.textContent = ballSlider.value;
+    settings.maxBalls = parseInt(ballSlider.value);
+  });
+
+  bulletDamageSlider.addEventListener('input', () => {
+    settings.bulletDamage = parseInt(bulletDamageSlider.value);
+    bulletDamageLabel.textContent = settings.bulletDamage;
+  });
+
+  ballDamageSlider.addEventListener('input', () => {
+    settings.ballDamage = parseInt(ballDamageSlider.value);
+    ballDamageLabel.textContent = settings.ballDamage;
+  });
+
+  Rabbit.faceOffset = parseFloat(faceSlider.value);
+  faceSlider.addEventListener('input', () => {
+    const v = parseFloat(faceSlider.value);
+    faceLabel.textContent = v.toFixed(2);
+    Rabbit.faceOffset = v;
+  });
+
+  const applyRabbitHealth = () => {
+    const v = parseInt(rabbitHealthSlider.value);
+    rabbitHealthLabel.textContent = v;
+    for (const r of rabbits) { r.maxHealth = v; r.health = v; }
+  };
+  rabbitHealthSlider.addEventListener('input', applyRabbitHealth);
+  applyRabbitHealth();
+
+  listener.setMasterVolume(parseFloat(volumeSlider.value));
+  volumeSlider.addEventListener('input', () => {
+    const v = parseFloat(volumeSlider.value);
+    volumeLabel.textContent = v.toFixed(2);
+    listener.setMasterVolume(v);
+  });
+
+  resumeButton.addEventListener('click', () => {
+    canvas.requestPointerLock();
+  });
+}


### PR DESCRIPTION
## Summary
- Add dedicated Resume button so settings stay open until the user resumes
- Modularize UI slider logic and audio/health updates in a new `settings.js`
- Prevent pointer lock from re-engaging when interacting with settings

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c779710a988321af5b09b11eaf5d28