### PR TITLE
Add modular settings menu with explicit resume

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
     <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="50" /> <span id="bulletDamageLabel">50</span></div>
     <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <span id="ballDamageLabel">10</span></div>
     <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
-    <p style="text-align:center;margin-top:12px;">Click the game to resume</p>
+    <div style="text-align:center;margin-top:12px;"><button id="resumeButton">Resume</button></div>
   </div>
 
   <script type="module" src="js/main.js"></script>

--- a/js/controls.js
+++ b/js/controls.js
@@ -5,7 +5,7 @@ export const controls = {
   pointerLocked: false
 };
 
-export function initControls(domElement, shoot, onPointerLockChange) {
+export function initControls(domElement, shoot, onPointerLockChange, canLockPointer) {
   const hint = document.getElementById('hint');
   addEventListener('keydown', e => {
     if (e.code === 'Escape' && controls.pointerLocked) {
@@ -20,8 +20,10 @@ export function initControls(domElement, shoot, onPointerLockChange) {
 
   addEventListener('mousedown', e => {
     if (!controls.pointerLocked) {
-      domElement.requestPointerLock();
-      e.preventDefault();
+      if (!canLockPointer || canLockPointer(e)) {
+        domElement.requestPointerLock();
+        e.preventDefault();
+      }
     } else if (e.button === 0) {
       shoot();
     }

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,73 @@
+import { Rabbit } from './rabbit.js';
+
+export function initSettings(domElement, rabbits, listener) {
+  const settings = document.getElementById('settings');
+  const resumeButton = document.getElementById('resumeButton');
+
+  const ballSlider = document.getElementById('ballSlider');
+  const ballCountLabel = document.getElementById('ballCountLabel');
+  const volumeSlider = document.getElementById('volumeSlider');
+  const volumeLabel = document.getElementById('volumeLabel');
+  const faceSlider = document.getElementById('faceSlider');
+  const faceLabel = document.getElementById('faceLabel');
+  const rabbitHealthSlider = document.getElementById('rabbitHealthSlider');
+  const rabbitHealthLabel = document.getElementById('rabbitHealthLabel');
+  const bulletDamageSlider = document.getElementById('bulletDamageSlider');
+  const bulletDamageLabel = document.getElementById('bulletDamageLabel');
+  const ballDamageSlider = document.getElementById('ballDamageSlider');
+  const ballDamageLabel = document.getElementById('ballDamageLabel');
+
+  let maxBalls = parseInt(ballSlider.value);
+  ballSlider.addEventListener('input', () => {
+    ballCountLabel.textContent = ballSlider.value;
+    maxBalls = parseInt(ballSlider.value);
+  });
+
+  let bulletDamage = parseInt(bulletDamageSlider.value);
+  bulletDamageSlider.addEventListener('input', () => {
+    bulletDamage = parseInt(bulletDamageSlider.value);
+    bulletDamageLabel.textContent = bulletDamage;
+  });
+
+  let ballDamage = parseInt(ballDamageSlider.value);
+  ballDamageSlider.addEventListener('input', () => {
+    ballDamage = parseInt(ballDamageSlider.value);
+    ballDamageLabel.textContent = ballDamage;
+  });
+
+  Rabbit.faceOffset = parseFloat(faceSlider.value);
+  faceSlider.addEventListener('input', () => {
+    const v = parseFloat(faceSlider.value);
+    faceLabel.textContent = v.toFixed(2);
+    Rabbit.faceOffset = v;
+  });
+
+  rabbitHealthSlider.addEventListener('input', () => {
+    const v = parseInt(rabbitHealthSlider.value);
+    rabbitHealthLabel.textContent = v;
+    for (const r of rabbits) { r.maxHealth = v; r.health = v; }
+  });
+
+  listener.setMasterVolume(parseFloat(volumeSlider.value));
+  volumeSlider.addEventListener('input', () => {
+    const v = parseFloat(volumeSlider.value);
+    volumeLabel.textContent = v.toFixed(2);
+    listener.setMasterVolume(v);
+  });
+
+  resumeButton.addEventListener('click', () => {
+    domElement.requestPointerLock();
+  });
+
+  function onPointerLockChange(locked) {
+    settings.classList.toggle('hidden', locked);
+  }
+
+  return {
+    settings,
+    onPointerLockChange,
+    getMaxBalls: () => maxBalls,
+    getBulletDamage: () => bulletDamage,
+    getBallDamage: () => ballDamage
+  };
+}


### PR DESCRIPTION
## Summary
- add Resume button to settings menu and move settings logic into new module
- only allow pointer lock when settings are hidden, requiring explicit resume
- use getters from settings module for dynamic damage and ball limits

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check js/settings.js js/controls.js js/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68c779710a988321af5b09b11eaf5d28