### PR TITLE
Add resume button for settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
     <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="50" /> <span id="bulletDamageLabel">50</span></div>
     <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <span id="ballDamageLabel">10</span></div>
     <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
-    <p style="text-align:center;margin-top:12px;">Click the game to resume</p>
+    <div style="text-align:center;margin-top:12px;"><button id="resumeButton">Resume</button></div>
   </div>
 
   <script type="module" src="js/main.js"></script>

--- a/js/controls.js
+++ b/js/controls.js
@@ -7,6 +7,8 @@ export const controls = {
 
 export function initControls(domElement, shoot, onPointerLockChange) {
   const hint = document.getElementById('hint');
+  const settings = document.getElementById('settings');
+  const resumeButton = document.getElementById('resumeButton');
   addEventListener('keydown', e => {
     if (e.code === 'Escape' && controls.pointerLocked) {
       document.exitPointerLock();
@@ -20,8 +22,15 @@ export function initControls(domElement, shoot, onPointerLockChange) {
 
   addEventListener('mousedown', e => {
     if (!controls.pointerLocked) {
-      domElement.requestPointerLock();
-      e.preventDefault();
+      if (!settings.classList.contains('hidden')) {
+        if (e.target === resumeButton) {
+          domElement.requestPointerLock();
+          e.preventDefault();
+        }
+      } else {
+        domElement.requestPointerLock();
+        e.preventDefault();
+      }
     } else if (e.button === 0) {
       shoot();
     }

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,7 @@
 import { controls, initControls } from "./controls.js";
 import { DayNightCycle } from './dayNight.js';
 import { Rabbit } from './rabbit.js';
+import { settings, initSettings, maxBalls, bulletDamage, ballDamage, getRabbitHealth } from './settings.js';
 import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
 export function startGame() {
 
@@ -12,52 +13,7 @@ renderer.setSize(innerWidth, innerHeight);
 renderer.shadowMap.enabled = true;
 app.appendChild(renderer.domElement);
 
-// UI controls
-const ballSlider = document.getElementById('ballSlider');
-const ballCountLabel = document.getElementById('ballCountLabel');
-const settings = document.getElementById('settings');
-const volumeSlider = document.getElementById('volumeSlider');
-const volumeLabel = document.getElementById('volumeLabel');
-const faceSlider = document.getElementById('faceSlider');
-const faceLabel = document.getElementById('faceLabel');
-const rabbitHealthSlider = document.getElementById('rabbitHealthSlider');
-const rabbitHealthLabel = document.getElementById('rabbitHealthLabel');
-const bulletDamageSlider = document.getElementById('bulletDamageSlider');
-const bulletDamageLabel = document.getElementById('bulletDamageLabel');
-const ballDamageSlider = document.getElementById('ballDamageSlider');
-const ballDamageLabel = document.getElementById('ballDamageLabel');
-
-let maxBalls = parseInt(ballSlider.value);
-ballSlider.addEventListener('input', () => {
-  ballCountLabel.textContent = ballSlider.value;
-  maxBalls = parseInt(ballSlider.value);
-});
-
-let bulletDamage = parseInt(bulletDamageSlider.value);
-bulletDamageSlider.addEventListener('input', () => {
-  bulletDamage = parseInt(bulletDamageSlider.value);
-  bulletDamageLabel.textContent = bulletDamage;
-});
-
-let ballDamage = parseInt(ballDamageSlider.value);
-ballDamageSlider.addEventListener('input', () => {
-  ballDamage = parseInt(ballDamageSlider.value);
-  ballDamageLabel.textContent = ballDamage;
-});
-
-Rabbit.faceOffset = parseFloat(faceSlider.value);
-faceSlider.addEventListener('input', () => {
-  const v = parseFloat(faceSlider.value);
-  faceLabel.textContent = v.toFixed(2);
-  Rabbit.faceOffset = v;
-});
-
 let rabbits = [];
-rabbitHealthSlider.addEventListener('input', () => {
-  const v = parseInt(rabbitHealthSlider.value);
-  rabbitHealthLabel.textContent = v;
-  for (const r of rabbits) { r.maxHealth = v; r.health = v; }
-});
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x7fb0ff);
@@ -76,12 +32,7 @@ scene.fog = new THREE.Fog(0x7fb0ff, 20, 140);
     nightSound.setLoop(true);
     nightSound.setVolume(1.0);
   });
-  listener.setMasterVolume(parseFloat(volumeSlider.value));
-  volumeSlider.addEventListener('input', () => {
-    const v = parseFloat(volumeSlider.value);
-    volumeLabel.textContent = v.toFixed(2);
-    listener.setMasterVolume(v);
-  });
+  initSettings(() => rabbits, listener);
 
 // --- Lights ---
 const hemi = new THREE.HemisphereLight(0xffffff, 0x335533, 0.6);
@@ -202,7 +153,7 @@ function updateHealthUI() {
       onAttack: () => { playerHealth *= 0.5; updateHealthUI(); }
     }, listener, audioLoader)
   ];
-  const rabbitMax = parseInt(rabbitHealthSlider.value);
+  const rabbitMax = getRabbitHealth();
   for (const r of rabbits) { r.maxHealth = rabbitMax; r.health = rabbitMax; }
 const dayNight = new DayNightCycle(scene, sun, hemi);
 controls.trappedUntil = 0;

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,69 @@
+import { Rabbit } from './rabbit.js';
+
+export const settings = document.getElementById('settings');
+export const resumeButton = document.getElementById('resumeButton');
+const ballSlider = document.getElementById('ballSlider');
+const ballCountLabel = document.getElementById('ballCountLabel');
+const volumeSlider = document.getElementById('volumeSlider');
+const volumeLabel = document.getElementById('volumeLabel');
+const faceSlider = document.getElementById('faceSlider');
+const faceLabel = document.getElementById('faceLabel');
+const rabbitHealthSlider = document.getElementById('rabbitHealthSlider');
+const rabbitHealthLabel = document.getElementById('rabbitHealthLabel');
+const bulletDamageSlider = document.getElementById('bulletDamageSlider');
+const bulletDamageLabel = document.getElementById('bulletDamageLabel');
+const ballDamageSlider = document.getElementById('ballDamageSlider');
+const ballDamageLabel = document.getElementById('ballDamageLabel');
+
+export let maxBalls = parseInt(ballSlider.value);
+export let bulletDamage = parseInt(bulletDamageSlider.value);
+export let ballDamage = parseInt(ballDamageSlider.value);
+
+export function getRabbitHealth() {
+  return parseInt(rabbitHealthSlider.value);
+}
+
+export function initSettings(getRabbits, listener) {
+  // initial label values
+  ballCountLabel.textContent = ballSlider.value;
+  bulletDamageLabel.textContent = bulletDamageSlider.value;
+  ballDamageLabel.textContent = ballDamageSlider.value;
+  faceLabel.textContent = parseFloat(faceSlider.value).toFixed(2);
+  rabbitHealthLabel.textContent = rabbitHealthSlider.value;
+  volumeLabel.textContent = parseFloat(volumeSlider.value).toFixed(2);
+  listener.setMasterVolume(parseFloat(volumeSlider.value));
+
+  ballSlider.addEventListener('input', () => {
+    ballCountLabel.textContent = ballSlider.value;
+    maxBalls = parseInt(ballSlider.value);
+  });
+
+  bulletDamageSlider.addEventListener('input', () => {
+    bulletDamage = parseInt(bulletDamageSlider.value);
+    bulletDamageLabel.textContent = bulletDamage;
+  });
+
+  ballDamageSlider.addEventListener('input', () => {
+    ballDamage = parseInt(ballDamageSlider.value);
+    ballDamageLabel.textContent = ballDamage;
+  });
+
+  Rabbit.faceOffset = parseFloat(faceSlider.value);
+  faceSlider.addEventListener('input', () => {
+    const v = parseFloat(faceSlider.value);
+    faceLabel.textContent = v.toFixed(2);
+    Rabbit.faceOffset = v;
+  });
+
+  rabbitHealthSlider.addEventListener('input', () => {
+    const v = parseInt(rabbitHealthSlider.value);
+    rabbitHealthLabel.textContent = v;
+    for (const r of getRabbits()) { r.maxHealth = v; r.health = v; }
+  });
+
+  volumeSlider.addEventListener('input', () => {
+    const v = parseFloat(volumeSlider.value);
+    volumeLabel.textContent = v.toFixed(2);
+    listener.setMasterVolume(v);
+  });
+}


### PR DESCRIPTION
## Summary
- Require dedicated Resume button before returning from settings
- Modularize settings sliders into separate module

## Testing
- `node --version`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c779710a988321af5b09b11eaf5d28