### PR TITLE
Revamp settings menu with editable values and dispenser fire rate

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,14 @@
       display: flex; align-items: center; margin: 8px 0;
     }
     .setting label { flex: 1; margin-right: 10px; }
-    .setting input[type=range] { flex: 2; }
-    .setting span { margin-left: 8px; width: 40px; text-align: right; }
+    .setting input[type=range] {
+      flex: 2; margin-right: 8px; accent-color: #4ade80;
+    }
+    .setting .value-input {
+      width: 60px; padding: 2px 4px; border-radius: 6px;
+      border: 1px solid #555; background: rgba(0,0,0,0.4); color: #e9eef5;
+      text-align: right;
+    }
 
     .cycle-ui {
       position: fixed; top: 16px; right: 16px;
@@ -102,12 +108,13 @@
 
   <div id="settings" class="settings hidden">
     <h2>Settings</h2>
-    <div class="setting"><label for="volumeSlider">Volume</label><input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /> <span id="volumeLabel">0.5</span></div>
-    <div class="setting"><label for="faceSlider">Face Offset</label><input type="range" id="faceSlider" min="0" max="1" step="0.01" value="0.05" /> <span id="faceLabel">0.05</span></div>
-    <div class="setting"><label for="rabbitHealthSlider">Rabbit Max Health</label><input type="range" id="rabbitHealthSlider" min="100" max="1000" value="500" /> <span id="rabbitHealthLabel">500</span></div>
-    <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="50" /> <span id="bulletDamageLabel">50</span></div>
-    <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <span id="ballDamageLabel">10</span></div>
-    <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
+    <div class="setting"><label for="volumeSlider">Volume</label><input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /> <input type="number" id="volumeInput" class="value-input" min="0" max="1" step="0.01" value="0.50" /></div>
+    <div class="setting"><label for="faceSlider">Face Offset</label><input type="range" id="faceSlider" min="0" max="1" step="0.01" value="1" /> <input type="number" id="faceInput" class="value-input" min="0" max="1" step="0.01" value="1.00" /></div>
+    <div class="setting"><label for="rabbitHealthSlider">Rabbit Max Health</label><input type="range" id="rabbitHealthSlider" min="100" max="1000" value="146" /> <input type="number" id="rabbitHealthInput" class="value-input" min="100" max="1000" value="146" /></div>
+    <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="200" /> <input type="number" id="bulletDamageInput" class="value-input" min="1" max="200" value="200" /></div>
+    <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <input type="number" id="ballDamageInput" class="value-input" min="1" max="200" value="10" /></div>
+    <div class="setting"><label for="dispenserRateSlider">Dispenser Fire Rate</label><input type="range" id="dispenserRateSlider" min="0.1" max="10" step="0.1" value="1" /> <input type="number" id="dispenserRateInput" class="value-input" min="0.1" max="10" step="0.1" value="1" /></div>
+    <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2020" /> <input type="number" id="ballCountInput" class="value-input" min="100" max="10000" value="2020" /></div>
     <div style="text-align:center;margin-top:12px;"><button id="resumeButton">Resume</button></div>
   </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -289,7 +289,7 @@ const GRAV = 22;
   // Spawn balls from dispensers
   for (const d of dispensers) {
     if (totalDispensed >= gameSettings.maxBalls) break;
-    if (now - d.last >= 1000) {
+    if (now - d.last >= 1000 / gameSettings.dispenserRate) {
       const mesh = new THREE.Mesh(ballGeo, ballMat);
       mesh.position.copy(d.pos).add(new THREE.Vector3(0, BALL_RADIUS, 0));
       mesh.castShadow = true; mesh.receiveShadow = true;

--- a/js/settings.js
+++ b/js/settings.js
@@ -3,65 +3,126 @@ import { Rabbit } from './rabbit.js';
 
 const settingsDiv = document.getElementById('settings');
 const ballSlider = document.getElementById('ballSlider');
-const ballCountLabel = document.getElementById('ballCountLabel');
+const ballCountInput = document.getElementById('ballCountInput');
 const volumeSlider = document.getElementById('volumeSlider');
-const volumeLabel = document.getElementById('volumeLabel');
+const volumeInput = document.getElementById('volumeInput');
 const faceSlider = document.getElementById('faceSlider');
-const faceLabel = document.getElementById('faceLabel');
+const faceInput = document.getElementById('faceInput');
 const rabbitHealthSlider = document.getElementById('rabbitHealthSlider');
-const rabbitHealthLabel = document.getElementById('rabbitHealthLabel');
+const rabbitHealthInput = document.getElementById('rabbitHealthInput');
 const bulletDamageSlider = document.getElementById('bulletDamageSlider');
-const bulletDamageLabel = document.getElementById('bulletDamageLabel');
+const bulletDamageInput = document.getElementById('bulletDamageInput');
 const ballDamageSlider = document.getElementById('ballDamageSlider');
-const ballDamageLabel = document.getElementById('ballDamageLabel');
+const ballDamageInput = document.getElementById('ballDamageInput');
+const dispenserRateSlider = document.getElementById('dispenserRateSlider');
+const dispenserRateInput = document.getElementById('dispenserRateInput');
 const resumeButton = document.getElementById('resumeButton');
 
 export const gameSettings = {
   maxBalls: parseInt(ballSlider.value),
   bulletDamage: parseInt(bulletDamageSlider.value),
-  ballDamage: parseInt(ballDamageSlider.value)
+  ballDamage: parseInt(ballDamageSlider.value),
+  dispenserRate: parseFloat(dispenserRateSlider.value)
 };
 
 export function initSettings(rabbits, listener, canvas) {
-  ballCountLabel.textContent = ballSlider.value;
+  ballCountInput.value = ballSlider.value;
   ballSlider.addEventListener('input', () => {
-    ballCountLabel.textContent = ballSlider.value;
+    ballCountInput.value = ballSlider.value;
     gameSettings.maxBalls = parseInt(ballSlider.value);
   });
-
-  bulletDamageLabel.textContent = gameSettings.bulletDamage;
-  bulletDamageSlider.addEventListener('input', () => {
-    gameSettings.bulletDamage = parseInt(bulletDamageSlider.value);
-    bulletDamageLabel.textContent = gameSettings.bulletDamage;
+  ballCountInput.addEventListener('change', () => {
+    let v = parseInt(ballCountInput.value);
+    if (isNaN(v)) return;
+    v = Math.max(parseInt(ballSlider.min), Math.min(parseInt(ballSlider.max), v));
+    ballSlider.value = v;
+    gameSettings.maxBalls = v;
   });
 
-  ballDamageLabel.textContent = gameSettings.ballDamage;
+  bulletDamageInput.value = gameSettings.bulletDamage;
+  bulletDamageSlider.addEventListener('input', () => {
+    gameSettings.bulletDamage = parseInt(bulletDamageSlider.value);
+    bulletDamageInput.value = gameSettings.bulletDamage;
+  });
+  bulletDamageInput.addEventListener('change', () => {
+    let v = parseInt(bulletDamageInput.value);
+    if (isNaN(v)) return;
+    v = Math.max(parseInt(bulletDamageSlider.min), Math.min(parseInt(bulletDamageSlider.max), v));
+    bulletDamageSlider.value = v;
+    gameSettings.bulletDamage = v;
+  });
+
+  ballDamageInput.value = gameSettings.ballDamage;
   ballDamageSlider.addEventListener('input', () => {
     gameSettings.ballDamage = parseInt(ballDamageSlider.value);
-    ballDamageLabel.textContent = gameSettings.ballDamage;
+    ballDamageInput.value = gameSettings.ballDamage;
+  });
+  ballDamageInput.addEventListener('change', () => {
+    let v = parseInt(ballDamageInput.value);
+    if (isNaN(v)) return;
+    v = Math.max(parseInt(ballDamageSlider.min), Math.min(parseInt(ballDamageSlider.max), v));
+    ballDamageSlider.value = v;
+    gameSettings.ballDamage = v;
   });
 
   Rabbit.faceOffset = parseFloat(faceSlider.value);
-  faceLabel.textContent = parseFloat(faceSlider.value).toFixed(2);
+  faceInput.value = parseFloat(faceSlider.value).toFixed(2);
   faceSlider.addEventListener('input', () => {
     const v = parseFloat(faceSlider.value);
-    faceLabel.textContent = v.toFixed(2);
+    faceInput.value = v.toFixed(2);
+    Rabbit.faceOffset = v;
+  });
+  faceInput.addEventListener('change', () => {
+    let v = parseFloat(faceInput.value);
+    if (isNaN(v)) return;
+    v = Math.max(parseFloat(faceSlider.min), Math.min(parseFloat(faceSlider.max), v));
+    faceSlider.value = v;
+    faceInput.value = v.toFixed(2);
     Rabbit.faceOffset = v;
   });
 
-  rabbitHealthLabel.textContent = rabbitHealthSlider.value;
+  rabbitHealthInput.value = rabbitHealthSlider.value;
   rabbitHealthSlider.addEventListener('input', () => {
     const v = parseInt(rabbitHealthSlider.value);
-    rabbitHealthLabel.textContent = v;
+    rabbitHealthInput.value = v;
+    for (const r of rabbits) { r.maxHealth = v; r.health = v; }
+  });
+  rabbitHealthInput.addEventListener('change', () => {
+    let v = parseInt(rabbitHealthInput.value);
+    if (isNaN(v)) return;
+    v = Math.max(parseInt(rabbitHealthSlider.min), Math.min(parseInt(rabbitHealthSlider.max), v));
+    rabbitHealthSlider.value = v;
     for (const r of rabbits) { r.maxHealth = v; r.health = v; }
   });
 
-  volumeLabel.textContent = parseFloat(volumeSlider.value).toFixed(2);
+  volumeInput.value = parseFloat(volumeSlider.value).toFixed(2);
   listener.setMasterVolume(parseFloat(volumeSlider.value));
   volumeSlider.addEventListener('input', () => {
     const v = parseFloat(volumeSlider.value);
-    volumeLabel.textContent = v.toFixed(2);
+    volumeInput.value = v.toFixed(2);
     listener.setMasterVolume(v);
+  });
+  volumeInput.addEventListener('change', () => {
+    let v = parseFloat(volumeInput.value);
+    if (isNaN(v)) return;
+    v = Math.max(parseFloat(volumeSlider.min), Math.min(parseFloat(volumeSlider.max), v));
+    volumeSlider.value = v;
+    volumeInput.value = v.toFixed(2);
+    listener.setMasterVolume(v);
+  });
+
+  dispenserRateInput.value = dispenserRateSlider.value;
+  dispenserRateSlider.addEventListener('input', () => {
+    const v = parseFloat(dispenserRateSlider.value);
+    dispenserRateInput.value = v;
+    gameSettings.dispenserRate = v;
+  });
+  dispenserRateInput.addEventListener('change', () => {
+    let v = parseFloat(dispenserRateInput.value);
+    if (isNaN(v)) return;
+    v = Math.max(parseFloat(dispenserRateSlider.min), Math.min(parseFloat(dispenserRateSlider.max), v));
+    dispenserRateSlider.value = v;
+    gameSettings.dispenserRate = v;
   });
 
   resumeButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Restyle settings UI and display value inputs alongside sliders
- Add a configurable dispenser fire rate option
- Set new default gameplay values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c77bac0e50832192242fa4c039d1dc