### PR TITLE
Improve settings menu and add dispenser rate control

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,21 +39,41 @@
     .settings {
       position: fixed;
       top: 50%; left: 50%; transform: translate(-50%, -50%);
-      padding: 20px 24px; border-radius: 14px;
-      background: rgba(20,22,24,0.9); color: #e9eef5;
+      padding: 24px 28px; border-radius: 16px;
+      background: linear-gradient(135deg, rgba(34,36,40,0.95), rgba(24,26,28,0.95));
+      color: #e9eef5;
       font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
-      min-width: 300px;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+      border: 1px solid rgba(255,255,255,0.1);
+      backdrop-filter: blur(8px);
+      min-width: 320px;
     }
     .settings h2 {
-      margin: 0 0 10px 0; text-align: center;
+      margin: 0 0 12px 0; text-align: center; font-size: 20px;
     }
     .setting {
-      display: flex; align-items: center; margin: 8px 0;
+      display: flex; align-items: center; margin: 10px 0;
     }
     .setting label { flex: 1; margin-right: 10px; }
-    .setting input[type=range] { flex: 2; }
-    .setting span { margin-left: 8px; width: 40px; text-align: right; }
+    .setting input[type=range] {
+      flex: 2;
+      -webkit-appearance: none;
+      height: 4px;
+      border-radius: 2px;
+      background: #444;
+    }
+    .setting input[type=range]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 14px; height: 14px;
+      border-radius: 50%;
+      background: #3fa9f5;
+      border: none;
+      box-shadow: 0 0 2px rgba(0,0,0,0.6);
+    }
+    .setting input[type=range]::-moz-range-thumb {
+      width: 14px; height: 14px; border-radius: 50%; background: #3fa9f5; border:none; box-shadow: 0 0 2px rgba(0,0,0,0.6);
+    }
+    .setting span { margin-left: 8px; width: 50px; text-align: right; cursor: pointer; }
 
     .cycle-ui {
       position: fixed; top: 16px; right: 16px;
@@ -102,12 +122,13 @@
 
   <div id="settings" class="settings hidden">
     <h2>Settings</h2>
-    <div class="setting"><label for="volumeSlider">Volume</label><input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /> <span id="volumeLabel">0.5</span></div>
-    <div class="setting"><label for="faceSlider">Face Offset</label><input type="range" id="faceSlider" min="0" max="1" step="0.01" value="0.05" /> <span id="faceLabel">0.05</span></div>
-    <div class="setting"><label for="rabbitHealthSlider">Rabbit Max Health</label><input type="range" id="rabbitHealthSlider" min="100" max="1000" value="500" /> <span id="rabbitHealthLabel">500</span></div>
-    <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="50" /> <span id="bulletDamageLabel">50</span></div>
+    <div class="setting"><label for="volumeSlider">Volume</label><input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /> <span id="volumeLabel">0.50</span></div>
+    <div class="setting"><label for="faceSlider">Face Offset</label><input type="range" id="faceSlider" min="0" max="1" step="0.01" value="1" /> <span id="faceLabel">1.00</span></div>
+    <div class="setting"><label for="rabbitHealthSlider">Rabbit Max Health</label><input type="range" id="rabbitHealthSlider" min="100" max="1000" value="146" /> <span id="rabbitHealthLabel">146</span></div>
+    <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="200" /> <span id="bulletDamageLabel">200</span></div>
     <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <span id="ballDamageLabel">10</span></div>
-    <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
+    <div class="setting"><label for="fireRateSlider">Dispenser Fire Rate</label><input type="range" id="fireRateSlider" min="0.1" max="10" step="0.1" value="1" /> <span id="fireRateLabel">1.00</span></div>
+    <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2020" /> <span id="ballCountLabel">2020</span></div>
     <div style="text-align:center;margin-top:12px;"><button id="resumeButton">Resume</button></div>
   </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -289,7 +289,7 @@ const GRAV = 22;
   // Spawn balls from dispensers
   for (const d of dispensers) {
     if (totalDispensed >= gameSettings.maxBalls) break;
-    if (now - d.last >= 1000) {
+    if (now - d.last >= 1000 / gameSettings.dispenserRate) {
       const mesh = new THREE.Mesh(ballGeo, ballMat);
       mesh.position.copy(d.pos).add(new THREE.Vector3(0, BALL_RADIUS, 0));
       mesh.castShadow = true; mesh.receiveShadow = true;

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,13 +14,29 @@ const bulletDamageSlider = document.getElementById('bulletDamageSlider');
 const bulletDamageLabel = document.getElementById('bulletDamageLabel');
 const ballDamageSlider = document.getElementById('ballDamageSlider');
 const ballDamageLabel = document.getElementById('ballDamageLabel');
+const fireRateSlider = document.getElementById('fireRateSlider');
+const fireRateLabel = document.getElementById('fireRateLabel');
 const resumeButton = document.getElementById('resumeButton');
 
 export const gameSettings = {
   maxBalls: parseInt(ballSlider.value),
   bulletDamage: parseInt(bulletDamageSlider.value),
-  ballDamage: parseInt(ballDamageSlider.value)
+  ballDamage: parseInt(ballDamageSlider.value),
+  dispenserRate: parseFloat(fireRateSlider.value)
 };
+
+function makeEditable(slider, label) {
+  label.addEventListener('click', () => {
+    const val = prompt('Enter value', slider.value);
+    if (val === null) return;
+    let num = parseFloat(val);
+    if (isNaN(num)) return;
+    if (slider.min !== '') num = Math.max(parseFloat(slider.min), num);
+    if (slider.max !== '') num = Math.min(parseFloat(slider.max), num);
+    slider.value = num;
+    slider.dispatchEvent(new Event('input'));
+  });
+}
 
 export function initSettings(rabbits, listener, canvas) {
   ballCountLabel.textContent = ballSlider.value;
@@ -28,18 +44,29 @@ export function initSettings(rabbits, listener, canvas) {
     ballCountLabel.textContent = ballSlider.value;
     gameSettings.maxBalls = parseInt(ballSlider.value);
   });
+  makeEditable(ballSlider, ballCountLabel);
 
   bulletDamageLabel.textContent = gameSettings.bulletDamage;
   bulletDamageSlider.addEventListener('input', () => {
     gameSettings.bulletDamage = parseInt(bulletDamageSlider.value);
     bulletDamageLabel.textContent = gameSettings.bulletDamage;
   });
+  makeEditable(bulletDamageSlider, bulletDamageLabel);
 
   ballDamageLabel.textContent = gameSettings.ballDamage;
   ballDamageSlider.addEventListener('input', () => {
     gameSettings.ballDamage = parseInt(ballDamageSlider.value);
     ballDamageLabel.textContent = gameSettings.ballDamage;
   });
+  makeEditable(ballDamageSlider, ballDamageLabel);
+
+  fireRateLabel.textContent = parseFloat(fireRateSlider.value).toFixed(2);
+  fireRateSlider.addEventListener('input', () => {
+    const v = parseFloat(fireRateSlider.value);
+    fireRateLabel.textContent = v.toFixed(2);
+    gameSettings.dispenserRate = v;
+  });
+  makeEditable(fireRateSlider, fireRateLabel);
 
   Rabbit.faceOffset = parseFloat(faceSlider.value);
   faceLabel.textContent = parseFloat(faceSlider.value).toFixed(2);
@@ -48,6 +75,7 @@ export function initSettings(rabbits, listener, canvas) {
     faceLabel.textContent = v.toFixed(2);
     Rabbit.faceOffset = v;
   });
+  makeEditable(faceSlider, faceLabel);
 
   rabbitHealthLabel.textContent = rabbitHealthSlider.value;
   rabbitHealthSlider.addEventListener('input', () => {
@@ -55,6 +83,7 @@ export function initSettings(rabbits, listener, canvas) {
     rabbitHealthLabel.textContent = v;
     for (const r of rabbits) { r.maxHealth = v; r.health = v; }
   });
+  makeEditable(rabbitHealthSlider, rabbitHealthLabel);
 
   volumeLabel.textContent = parseFloat(volumeSlider.value).toFixed(2);
   listener.setMasterVolume(parseFloat(volumeSlider.value));
@@ -63,6 +92,7 @@ export function initSettings(rabbits, listener, canvas) {
     volumeLabel.textContent = v.toFixed(2);
     listener.setMasterVolume(v);
   });
+  makeEditable(volumeSlider, volumeLabel);
 
   resumeButton.addEventListener('click', () => {
     controls.allowPointerLock = true;


### PR DESCRIPTION
## Summary
- Revamp settings UI with gradient styling and custom sliders
- Make all setting values editable via click
- Add "Dispenser Fire Rate" slider and new defaults for existing settings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c77bac0e50832192242fa4c039d1dc