### PR TITLE
Improve settings UI with editable fields and dispenser rate

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,13 @@
     .settings {
       position: fixed;
       top: 50%; left: 50%; transform: translate(-50%, -50%);
-      padding: 20px 24px; border-radius: 14px;
-      background: rgba(20,22,24,0.9); color: #e9eef5;
+      padding: 24px 30px; border-radius: 14px;
+      background: radial-gradient(circle at top, rgba(40,44,52,0.95), rgba(20,22,24,0.95));
+      border: 1px solid rgba(255,255,255,0.1);
+      color: #e9eef5;
       font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
-      min-width: 300px;
+      box-shadow: 0 6px 24px rgba(0,0,0,0.45); backdrop-filter: blur(6px);
+      min-width: 320px;
     }
     .settings h2 {
       margin: 0 0 10px 0; text-align: center;
@@ -52,8 +54,27 @@
       display: flex; align-items: center; margin: 8px 0;
     }
     .setting label { flex: 1; margin-right: 10px; }
-    .setting input[type=range] { flex: 2; }
-    .setting span { margin-left: 8px; width: 40px; text-align: right; }
+    .setting input[type=range] { flex: 2; accent-color: #2ecc71; }
+    .setting .value-input {
+      margin-left: 8px;
+      width: 60px;
+      text-align: right;
+      background: rgba(0,0,0,0.3);
+      border: 1px solid #555;
+      border-radius: 6px;
+      color: #fff;
+      padding: 2px 4px;
+    }
+
+    button#resumeButton {
+      background: #2ecc71;
+      border: none;
+      color: #fff;
+      padding: 8px 16px;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+    button#resumeButton:hover { background: #27ae60; }
 
     .cycle-ui {
       position: fixed; top: 16px; right: 16px;
@@ -102,12 +123,13 @@
 
   <div id="settings" class="settings hidden">
     <h2>Settings</h2>
-    <div class="setting"><label for="volumeSlider">Volume</label><input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /> <span id="volumeLabel">0.5</span></div>
-    <div class="setting"><label for="faceSlider">Face Offset</label><input type="range" id="faceSlider" min="0" max="1" step="0.01" value="0.05" /> <span id="faceLabel">0.05</span></div>
-    <div class="setting"><label for="rabbitHealthSlider">Rabbit Max Health</label><input type="range" id="rabbitHealthSlider" min="100" max="1000" value="500" /> <span id="rabbitHealthLabel">500</span></div>
-    <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="50" /> <span id="bulletDamageLabel">50</span></div>
-    <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <span id="ballDamageLabel">10</span></div>
-    <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2000" /> <span id="ballCountLabel">2000</span></div>
+    <div class="setting"><label for="volumeSlider">Volume</label><input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /> <input type="number" id="volumeLabel" min="0" max="1" step="0.01" value="0.5" class="value-input" /></div>
+    <div class="setting"><label for="faceSlider">Face Offset</label><input type="range" id="faceSlider" min="0" max="1" step="0.01" value="1" /> <input type="number" id="faceLabel" min="0" max="1" step="0.01" value="1" class="value-input" /></div>
+    <div class="setting"><label for="rabbitHealthSlider">Rabbit Max Health</label><input type="range" id="rabbitHealthSlider" min="100" max="1000" value="146" /> <input type="number" id="rabbitHealthLabel" min="100" max="1000" step="1" value="146" class="value-input" /></div>
+    <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="200" /> <input type="number" id="bulletDamageLabel" min="1" max="200" step="1" value="200" class="value-input" /></div>
+    <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <input type="number" id="ballDamageLabel" min="1" max="200" step="1" value="10" class="value-input" /></div>
+    <div class="setting"><label for="ballRateSlider">Dispenser Rate</label><input type="range" id="ballRateSlider" min="0.1" max="5" step="0.1" value="1" /> <input type="number" id="ballRateLabel" min="0.1" max="5" step="0.1" value="1" class="value-input" /></div>
+    <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2020" step="10" /> <input type="number" id="ballCountLabel" min="100" max="10000" step="10" value="2020" class="value-input" /></div>
     <div style="text-align:center;margin-top:12px;"><button id="resumeButton">Resume</button></div>
   </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -289,7 +289,8 @@ const GRAV = 22;
   // Spawn balls from dispensers
   for (const d of dispensers) {
     if (totalDispensed >= gameSettings.maxBalls) break;
-    if (now - d.last >= 1000) {
+    const interval = 1000 / gameSettings.dispenserRate;
+    if (now - d.last >= interval) {
       const mesh = new THREE.Mesh(ballGeo, ballMat);
       mesh.position.copy(d.pos).add(new THREE.Vector3(0, BALL_RADIUS, 0));
       mesh.castShadow = true; mesh.receiveShadow = true;

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,55 +14,33 @@ const bulletDamageSlider = document.getElementById('bulletDamageSlider');
 const bulletDamageLabel = document.getElementById('bulletDamageLabel');
 const ballDamageSlider = document.getElementById('ballDamageSlider');
 const ballDamageLabel = document.getElementById('ballDamageLabel');
+const ballRateSlider = document.getElementById('ballRateSlider');
+const ballRateLabel = document.getElementById('ballRateLabel');
 const resumeButton = document.getElementById('resumeButton');
 
 export const gameSettings = {
   maxBalls: parseInt(ballSlider.value),
   bulletDamage: parseInt(bulletDamageSlider.value),
-  ballDamage: parseInt(ballDamageSlider.value)
+  ballDamage: parseInt(ballDamageSlider.value),
+  dispenserRate: parseFloat(ballRateSlider.value)
 };
+function bind(slider, input, parse, onChange) {
+  const handle = v => onChange(parse(v));
+  input.value = slider.value;
+  slider.addEventListener('input', () => { input.value = slider.value; handle(slider.value); });
+  input.addEventListener('input', () => { slider.value = input.value; handle(input.value); });
+  handle(slider.value);
+}
 
 export function initSettings(rabbits, listener, canvas) {
-  ballCountLabel.textContent = ballSlider.value;
-  ballSlider.addEventListener('input', () => {
-    ballCountLabel.textContent = ballSlider.value;
-    gameSettings.maxBalls = parseInt(ballSlider.value);
-  });
+  bind(ballSlider, ballCountLabel, parseInt, v => gameSettings.maxBalls = v);
+  bind(bulletDamageSlider, bulletDamageLabel, parseInt, v => gameSettings.bulletDamage = v);
+  bind(ballDamageSlider, ballDamageLabel, parseInt, v => gameSettings.ballDamage = v);
+  bind(ballRateSlider, ballRateLabel, parseFloat, v => gameSettings.dispenserRate = v);
 
-  bulletDamageLabel.textContent = gameSettings.bulletDamage;
-  bulletDamageSlider.addEventListener('input', () => {
-    gameSettings.bulletDamage = parseInt(bulletDamageSlider.value);
-    bulletDamageLabel.textContent = gameSettings.bulletDamage;
-  });
-
-  ballDamageLabel.textContent = gameSettings.ballDamage;
-  ballDamageSlider.addEventListener('input', () => {
-    gameSettings.ballDamage = parseInt(ballDamageSlider.value);
-    ballDamageLabel.textContent = gameSettings.ballDamage;
-  });
-
-  Rabbit.faceOffset = parseFloat(faceSlider.value);
-  faceLabel.textContent = parseFloat(faceSlider.value).toFixed(2);
-  faceSlider.addEventListener('input', () => {
-    const v = parseFloat(faceSlider.value);
-    faceLabel.textContent = v.toFixed(2);
-    Rabbit.faceOffset = v;
-  });
-
-  rabbitHealthLabel.textContent = rabbitHealthSlider.value;
-  rabbitHealthSlider.addEventListener('input', () => {
-    const v = parseInt(rabbitHealthSlider.value);
-    rabbitHealthLabel.textContent = v;
-    for (const r of rabbits) { r.maxHealth = v; r.health = v; }
-  });
-
-  volumeLabel.textContent = parseFloat(volumeSlider.value).toFixed(2);
-  listener.setMasterVolume(parseFloat(volumeSlider.value));
-  volumeSlider.addEventListener('input', () => {
-    const v = parseFloat(volumeSlider.value);
-    volumeLabel.textContent = v.toFixed(2);
-    listener.setMasterVolume(v);
-  });
+  bind(faceSlider, faceLabel, parseFloat, v => { Rabbit.faceOffset = v; });
+  bind(rabbitHealthSlider, rabbitHealthLabel, parseInt, v => { for (const r of rabbits) { r.maxHealth = v; r.health = v; } });
+  bind(volumeSlider, volumeLabel, parseFloat, v => { listener.setMasterVolume(v); });
 
   resumeButton.addEventListener('click', () => {
     controls.allowPointerLock = true;


### PR DESCRIPTION
## Summary
- Refresh settings menu styling and add number inputs for direct editing
- Set new defaults and introduce dispenser fire rate slider
- Hook dispenser rate into game settings to control ball spawn speed

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c77bac0e50832192242fa4c039d1dc