### PR TITLE
Reduce rabbit size

### DIFF
--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -26,7 +26,7 @@ function makeRabbit() {
   const eyeR = eyeL.clone(); eyeR.position.x = 0.2;
 
   g.add(body, head, earL, earR, eyeL, eyeR);
-  g.scale.set(2.2, 2.2, 2.2);
+  g.scale.set(0.44, 0.44, 0.44);
   return g;
 }
 


### PR DESCRIPTION
## Summary
- shrink the rabbit mesh group scale to 20% of its previous value so all rabbits appear smaller

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cab23052e88321837163bf59eff4f6