### PR TITLE
Shrink rabbits to 20 percent size

### DIFF
--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -26,7 +26,8 @@ function makeRabbit() {
   const eyeR = eyeL.clone(); eyeR.position.x = 0.2;
 
   g.add(body, head, earL, earR, eyeL, eyeR);
-  g.scale.set(2.2, 2.2, 2.2);
+  const scaleFactor = 2.2 * 0.2; // shrink rabbits to 20% of their previous size
+  g.scale.set(scaleFactor, scaleFactor, scaleFactor);
   return g;
 }
 


### PR DESCRIPTION
## Summary
- reduce the rabbit group scale so each rabbit renders at 20% of its previous size

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cab23052e88321837163bf59eff4f6