### PR TITLE
Hide rabbit health bars when behind camera

### DIFF
--- a/js/rabbit.js
+++ b/js/rabbit.js
@@ -229,8 +229,20 @@ function createCave() {
 
   updateHealthBar(camera) {
     const disp = this.visible && this.health > 0;
-    this.healthBar.style.display = disp ? 'block' : 'none';
-    if (!disp) return;
+    if (!disp) {
+      this.healthBar.style.display = 'none';
+      return;
+    }
+
+    const cameraDir = new THREE.Vector3();
+    camera.getWorldDirection(cameraDir);
+    const toRabbit = this.mesh.position.clone().sub(camera.position);
+    if (toRabbit.dot(cameraDir) <= 0) {
+      this.healthBar.style.display = 'none';
+      return;
+    }
+
+    this.healthBar.style.display = 'block';
     const pos = this.mesh.position.clone();
     pos.y += 3;
     pos.project(camera);


### PR DESCRIPTION
## Summary
- hide rabbit health bars whenever the camera is facing away from the rabbit
- ensure the UI element remains hidden when the rabbit is not visible

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cab2bdce748321a8972f60a6bbfc83