### PR TITLE
Three.js FNAF-style night-shift MVP with modular systems

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,138 +1,99 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Low‑Poly Forest Shooter</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Night Shift MVP (Three.js)</title>
   <style>
-    html, body { height: 100%; margin: 0; overflow: hidden; background: #202428; }
+    :root { color-scheme: dark; }
+    html, body { margin: 0; height: 100%; overflow: hidden; background: #050508; font-family: Inter, system-ui, -apple-system, sans-serif; }
     #app { position: fixed; inset: 0; }
     canvas { display: block; }
-    .ui {
-      position: fixed; left: 50%; transform: translateX(-50%);
-      bottom: 16px; padding: 10px 14px; border-radius: 14px;
-      background: rgba(20,22,24,0.65); color: #e9eef5; font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
-      user-select: none; pointer-events: none;
-    }
-    .ui b { color: #fff; }
-    .crosshair {
-      position: fixed; left: 50%; top: 50%; transform: translate(-50%, -50%);
-      width: 14px; height: 14px; pointer-events: none; opacity: 0.85;
-    }
-    .crosshair:before, .crosshair:after {
-      content: ""; position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
-      background: #e9eef5; border-radius: 2px;
-    }
-    .crosshair:before { width: 14px; height: 2px; }
-    .crosshair:after  { width: 2px; height: 14px; }
-    .hint {
-      position: fixed; top: 16px; left: 50%; transform: translateX(-50%);
-      padding: 10px 14px; border-radius: 14px; color: #f1f5f9;
-      background: rgba(0,0,0,0.45); backdrop-filter: blur(4px);
-      font: 13px/1.3 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35);
-      text-align: center;
-    }
-    .hidden { display: none; }
 
-    .settings {
+    .hud {
       position: fixed;
-      top: 50%; left: 50%; transform: translate(-50%, -50%);
-      padding: 24px 30px; border-radius: 14px;
-      background: radial-gradient(circle at top, rgba(40,44,52,0.95), rgba(20,22,24,0.95));
-      border: 1px solid rgba(255,255,255,0.1);
-      color: #e9eef5;
-      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.45); backdrop-filter: blur(6px);
-      min-width: 320px;
-    }
-    .settings h2 {
-      margin: 0 0 10px 0; text-align: center;
-    }
-    .setting {
-      display: flex; align-items: center; margin: 8px 0;
-    }
-    .setting label { flex: 1; margin-right: 10px; }
-    .setting input[type=range] { flex: 2; accent-color: #2ecc71; }
-    .setting .value-input {
-      margin-left: 8px;
-      width: 60px;
-      text-align: right;
-      background: rgba(0,0,0,0.3);
-      border: 1px solid #555;
-      border-radius: 6px;
-      color: #fff;
-      padding: 2px 4px;
+      top: 12px;
+      left: 12px;
+      display: flex;
+      gap: 10px;
+      z-index: 5;
+      font-weight: 700;
     }
 
-    button#resumeButton {
-      background: #2ecc71;
-      border: none;
-      color: #fff;
-      padding: 8px 16px;
+    .chip {
+      background: rgba(15, 15, 22, 0.85);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: 10px;
+      padding: 8px 12px;
+      letter-spacing: 0.4px;
+    }
+
+    #instructions {
+      position: fixed;
+      right: 12px;
+      top: 12px;
+      z-index: 10;
+      width: min(360px, calc(100vw - 24px));
+      background: rgba(10, 10, 14, 0.9);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 12px;
+      padding: 12px;
+      line-height: 1.35;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+    }
+
+    #instructions h2 { margin: 0 0 8px 0; font-size: 16px; }
+    #instructions p, #instructions ul { margin: 8px 0; font-size: 13px; color: #d7d7e0; }
+    #instructions ul { padding-left: 18px; }
+    #instructions button {
+      margin-top: 8px;
+      border: 0;
       border-radius: 8px;
+      padding: 7px 10px;
+      background: #ffd94f;
+      color: #1f1400;
+      font-weight: 700;
       cursor: pointer;
     }
-    button#resumeButton:hover { background: #27ae60; }
 
-    .cycle-ui {
-      position: fixed; top: 16px; right: 16px;
-      width: 60px; height: 60px;
-    }
-    .cycle-ui svg { width: 100%; height: 100%; }
-    .cycle-ui .bg { stroke: rgba(255,255,255,0.25); stroke-width:4; fill:none; }
-    .cycle-ui .progress { stroke:#fff; stroke-width:4; fill:none; transform: rotate(-90deg); transform-origin: 50% 50%; }
-    .cycle-icon { position: absolute; top:50%; left:50%; transform: translate(-50%, -50%); font-size:24px; }
-    .health-ui {
-      position: fixed; bottom: 16px; left: 16px;
-      padding: 8px 12px; border-radius: 10px;
-      background: rgba(20,22,24,0.65); color: #e9eef5;
-      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
-      user-select: none;
-    }
-    .rabbit-health {
+    #flashlight-indicator.on { color: #ffd94f; }
+
+    #event-log {
       position: fixed;
-      width: 60px;
-      height: 8px;
-      background: rgba(80,0,0,0.8);
-      border: 1px solid #300;
-      pointer-events: none;
-    }
-    .rabbit-health .fill {
-      background: #2ecc71;
-      height: 100%;
-      width: 100%;
-    }
-    .rabbit-health .label {
-      position: absolute;
-      top: -14px;
-      left: 50%;
-      transform: translateX(-50%);
-      color: #fff;
-      font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      left: 12px;
+      bottom: 12px;
+      z-index: 5;
+      background: rgba(15, 15, 22, 0.78);
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      border-radius: 10px;
+      padding: 8px 10px;
+      min-width: 220px;
+      font-size: 12px;
     }
   </style>
 </head>
 <body>
   <div id="app"></div>
-  <div class="crosshair"></div>
-    <div class="hint" id="hint">Click to lock the mouse (<b>Esc</b> to release). <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
-  <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
 
-  <div id="settings" class="settings hidden">
-    <h2>Settings</h2>
-    <div class="setting"><label for="volumeSlider">Volume</label><input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /> <input type="number" id="volumeLabel" min="0" max="1" step="0.01" value="0.5" class="value-input" /></div>
-    <div class="setting"><label for="faceSlider">Face Offset</label><input type="range" id="faceSlider" min="0" max="1" step="0.01" value="1" /> <input type="number" id="faceLabel" min="0" max="1" step="0.01" value="1" class="value-input" /></div>
-    <div class="setting"><label for="rabbitHealthSlider">Rabbit Max Health</label><input type="range" id="rabbitHealthSlider" min="100" max="1000" value="146" /> <input type="number" id="rabbitHealthLabel" min="100" max="1000" step="1" value="146" class="value-input" /></div>
-    <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="200" /> <input type="number" id="bulletDamageLabel" min="1" max="200" step="1" value="200" class="value-input" /></div>
-    <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <input type="number" id="ballDamageLabel" min="1" max="200" step="1" value="10" class="value-input" /></div>
-    <div class="setting"><label for="ballRateSlider">Dispenser Rate</label><input type="range" id="ballRateSlider" min="0.1" max="5" step="0.1" value="1" /> <input type="number" id="ballRateLabel" min="0.1" max="5" step="0.1" value="1" class="value-input" /></div>
-    <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2020" step="10" /> <input type="number" id="ballCountLabel" min="100" max="10000" step="10" value="2020" class="value-input" /></div>
-    <div style="text-align:center;margin-top:12px;"><button id="resumeButton">Resume</button></div>
+  <div class="hud">
+    <div class="chip" id="clock">12:00 AM</div>
+    <div class="chip" id="flashlight-indicator">Flashlight: OFF</div>
   </div>
 
-  <script type="module" src="js/main.js"></script>
+  <aside id="instructions">
+    <h2>Night Shift Instructions</h2>
+    <p>Survive until 6:00 AM. The figure appears around <b>2 AM, 3 AM, 4 AM, and 5 AM</b>.</p>
+    <ul>
+      <li><b>A / D</b>: look left and right</li>
+      <li><b>W / S</b>: subtle forward/back lean</li>
+      <li><b>F</b>: toggle flashlight</li>
+      <li><b>H</b>: show/hide this help panel</li>
+    </ul>
+    <button id="close-help" type="button">Close Help</button>
+  </aside>
+
+  <div id="event-log">Night started. Keep the flashlight ready.</div>
+
+  <script type="module" src="./js/main.js"></script>
 </body>
 </html>

--- a/js/clock.js
+++ b/js/clock.js
@@ -1,0 +1,23 @@
+export function createNightClock(totalSeconds) {
+  let elapsed = 0;
+
+  return {
+    update(dt) {
+      elapsed = Math.min(totalSeconds, elapsed + dt);
+    },
+    getHourFloat() {
+      return 12 + (elapsed / totalSeconds) * 6;
+    },
+    getFormattedTime() {
+      const hourFloat = 12 + (elapsed / totalSeconds) * 6;
+      let hour = Math.floor(hourFloat);
+      const minute = Math.floor((hourFloat % 1) * 60);
+      if (hour >= 13) hour -= 12;
+      const ampm = 'AM';
+      return `${hour}:${String(minute).padStart(2, '0')} ${ampm}`;
+    },
+    isComplete() {
+      return elapsed >= totalSeconds;
+    }
+  };
+}

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,9 @@
+export const GAME_CONFIG = {
+  nightDurationSeconds: 180,
+  officeLookLimit: 0.85,
+  lookSensitivity: 1.4,
+  leanSensitivity: 0.8,
+  enemyRevealTimes: [2, 3, 4, 5],
+  enemyRevealWindowHours: 0.32,
+  enemyGraceSeconds: 9
+};

--- a/js/enemy.js
+++ b/js/enemy.js
@@ -1,0 +1,63 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+
+const SPAWN_POINTS = [
+  new THREE.Vector3(-6.2, 1.3, -2.8),
+  new THREE.Vector3(0, 1.3, -4.1),
+  new THREE.Vector3(6.2, 1.3, -2.8)
+];
+
+export function createEnemy(scene, revealTimes, revealWindowHours) {
+  const enemy = new THREE.Group();
+
+  const body = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.5, 0.8, 2.4, 12),
+    new THREE.MeshStandardMaterial({ color: 0x111111 })
+  );
+  body.position.y = 1.2;
+
+  const faceTexture = new THREE.TextureLoader().load('./assets/faces/face2.png');
+  const face = new THREE.Mesh(
+    new THREE.PlaneGeometry(1.15, 1.15),
+    new THREE.MeshBasicMaterial({ map: faceTexture, transparent: true })
+  );
+  face.position.set(0, 1.75, 0.52);
+
+  enemy.add(body);
+  enemy.add(face);
+  enemy.visible = false;
+  scene.add(enemy);
+
+  let activeSlot = -1;
+
+  return {
+    update(hourFloat, flashlightOn, dt) {
+      const activeIndex = revealTimes.findIndex((hour) => {
+        return hourFloat >= hour && hourFloat <= hour + revealWindowHours;
+      });
+
+      if (activeIndex !== activeSlot) {
+        activeSlot = activeIndex;
+        if (activeSlot >= 0) {
+          enemy.position.copy(SPAWN_POINTS[activeSlot % SPAWN_POINTS.length]);
+        }
+      }
+
+      const shouldExist = activeSlot >= 0;
+      enemy.visible = shouldExist;
+
+      if (enemy.visible) {
+        enemy.lookAt(0, 1.6, 7.8);
+        const pulse = 0.55 + Math.sin(performance.now() * 0.005) * 0.06;
+        face.material.opacity = flashlightOn ? 1 : 0.18;
+        body.material.emissive = flashlightOn ? new THREE.Color(0x330000) : new THREE.Color(0x000000);
+        body.material.emissiveIntensity = flashlightOn ? pulse : 0;
+      }
+
+      return {
+        active: shouldExist,
+        visibleWithFlashlight: shouldExist && flashlightOn,
+        delta: dt
+      };
+    }
+  };
+}

--- a/js/game.js
+++ b/js/game.js
@@ -1,391 +1,78 @@
-import { controls, initControls } from "./controls.js";
-import { DayNightCycle } from './dayNight.js';
-import { Rabbit } from './rabbit.js';
-import { initSettings, showSettings, gameSettings } from './settings.js';
-import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+import { createScene } from './scene.js';
+import { createInput } from './input.js';
+import { createNightClock } from './clock.js';
+import { createEnemy } from './enemy.js';
+import { createUI } from './ui.js';
+import { GAME_CONFIG } from './config.js';
+
 export function startGame() {
+  const app = document.getElementById('app');
+  const ui = createUI();
+  const input = createInput();
+  const { scene, camera, renderer, flashlight } = createScene(app);
 
-// --- Renderer & Scene ---
-const app = document.getElementById('app');
-const renderer = new THREE.WebGLRenderer({ antialias: true });
-renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
-renderer.setSize(innerWidth, innerHeight);
-renderer.shadowMap.enabled = true;
-app.appendChild(renderer.domElement);
+  const gameClock = createNightClock(GAME_CONFIG.nightDurationSeconds);
+  const enemy = createEnemy(scene, GAME_CONFIG.enemyRevealTimes, GAME_CONFIG.enemyRevealWindowHours);
 
-let rabbits = [];
+  let lookX = 0;
+  let lean = 0;
+  let lastTime = performance.now();
+  let exposureDanger = 0;
+  let won = false;
 
-const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x7fb0ff);
-scene.fog = new THREE.Fog(0x7fb0ff, 20, 140);
+  const update = (now) => {
+    const dt = Math.min(0.05, (now - lastTime) / 1000);
+    lastTime = now;
 
-  // --- Camera (third‑person follow) ---
-  const camera = new THREE.PerspectiveCamera(70, innerWidth/innerHeight, 0.1, 500);
+    const lookDir = (input.isDown('KeyD') ? 1 : 0) - (input.isDown('KeyA') ? 1 : 0);
+    const leanDir = (input.isDown('KeyW') ? 1 : 0) - (input.isDown('KeyS') ? 1 : 0);
 
-  // Audio setup
-  const listener = new THREE.AudioListener();
-  camera.add(listener);
-  const audioLoader = new THREE.AudioLoader();
-  const nightSound = new THREE.Audio(listener);
-  audioLoader.load('audio/horror-drone.wav', (buffer) => {
-    nightSound.setBuffer(buffer);
-    nightSound.setLoop(true);
-    nightSound.setVolume(1.0);
-  });
+    lookX += lookDir * GAME_CONFIG.lookSensitivity * dt;
+    lean += leanDir * GAME_CONFIG.leanSensitivity * dt;
+    lookX *= 0.92;
+    lean *= 0.9;
 
-// --- Lights ---
-const hemi = new THREE.HemisphereLight(0xffffff, 0x335533, 0.6);
-scene.add(hemi);
+    lookX = Math.max(-GAME_CONFIG.officeLookLimit, Math.min(GAME_CONFIG.officeLookLimit, lookX));
+    lean = Math.max(-0.35, Math.min(0.35, lean));
 
-const sun = new THREE.DirectionalLight(0xffffff, 1.0);
-sun.position.set(40, 60, 20);
-sun.castShadow = true;
-sun.shadow.mapSize.set(2048, 2048);
-sun.shadow.camera.near = 1;
-sun.shadow.camera.far = 200;
-sun.shadow.camera.left = -80;
-sun.shadow.camera.right = 80;
-sun.shadow.camera.top = 80;
-sun.shadow.camera.bottom = -80;
-scene.add(sun);
+    camera.position.x = lookX * 2.1;
+    camera.position.y = 1.8 + lean * 0.7;
+    camera.lookAt(lookX * 3.2, 1.6 + lean * 0.3, -4.8);
 
-// --- Ground ---
-const groundSize = 240;
-const groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, 1, 1);
-const groundMat = new THREE.MeshLambertMaterial({ color: 0x6dbb4b }); // grassy green
-const ground = new THREE.Mesh(groundGeo, groundMat);
-ground.rotation.x = -Math.PI/2;
-ground.receiveShadow = true;
-scene.add(ground);
+    const flashlightOn = input.isFlashlightOn();
+    flashlight.intensity = flashlightOn ? 3.6 : 0;
+    flashlight.target.position.set(lookX * 3.1, 1.5 + lean * 0.2, -5.2);
+    flashlight.target.updateMatrixWorld();
 
-// --- Low‑poly Tree Factory ---
-function makeTree() {
-  const group = new THREE.Group();
-  const trunk = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.25, 0.35, 2.5, 6),
-    new THREE.MeshLambertMaterial({ color: 0x8b5a2b })
-  );
-  trunk.castShadow = true; trunk.receiveShadow = true;
-  trunk.position.y = 1.25;
+    gameClock.update(dt);
+    ui.setClock(gameClock.getFormattedTime());
+    ui.setFlashlight(flashlightOn);
 
-  const foliage = new THREE.Mesh(
-    new THREE.ConeGeometry(1.6, 3.2, 6),
-    new THREE.MeshLambertMaterial({ color: 0x2f8f46 })
-  );
-  foliage.castShadow = true; foliage.receiveShadow = true;
-  foliage.position.y = 1.25 + 1.6;
+    const enemyState = enemy.update(gameClock.getHourFloat(), flashlightOn, dt);
 
-  const cap = new THREE.Mesh(
-    new THREE.ConeGeometry(1.2, 2.2, 6),
-    new THREE.MeshLambertMaterial({ color: 0x2a7a3d })
-  );
-  cap.castShadow = true; cap.receiveShadow = true;
-  cap.position.y = foliage.position.y + 1.1;
-
-  group.add(trunk, foliage, cap);
-  return group;
-}
-
-// Scatter trees but keep a clearing near the spawn
-const rng = (min,max)=>Math.random()*(max-min)+min;
-const trees = [];
-for (let i=0;i<220;i++){
-  const t = makeTree();
-  const r = groundSize*0.48;
-  let x, z; let tries = 0;
-  do {
-    x = rng(-r, r); z = rng(-r, r); tries++;
-  } while (tries < 50 && Math.hypot(x, z) < 12); // keep spawn clearing
-  t.position.set(x, 0, z);
-  t.rotation.y = rng(0, Math.PI*2);
-  const s = rng(0.8, 1.4); t.scale.setScalar(s);
-  trees.push(t);
-  scene.add(t);
-}
-
-// --- Player (generic low‑poly, Fortnite‑inspired POV) ---
-const player = new THREE.Group();
-
-// Body parts
-const body = new THREE.Mesh(new THREE.BoxGeometry(0.9, 1.2, 0.5), new THREE.MeshLambertMaterial({ color: 0x3b82f6 }));
-body.position.y = 1.1; body.castShadow = true; body.receiveShadow = true;
-
-const head = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.5, 0.5), new THREE.MeshLambertMaterial({ color: 0xf1f5f9 }));
-head.position.y = 1.1 + 0.85; head.castShadow = true;
-
-const legL = new THREE.Mesh(new THREE.BoxGeometry(0.35, 0.9, 0.35), new THREE.MeshLambertMaterial({ color: 0x1f2937 }));
-const legR = legL.clone();
-legL.position.set(-0.22, 0.45, 0);
-legR.position.set( 0.22, 0.45, 0);
-
-const armL = new THREE.Mesh(new THREE.BoxGeometry(0.25, 0.9, 0.25), new THREE.MeshLambertMaterial({ color: 0x3b82f6 }));
-const armR = armL.clone();
-armL.position.set(-0.6, 1.2, 0);
-armR.position.set( 0.6, 1.2, 0);
-
-// Simple blaster
-const gun = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.2, 0.2), new THREE.MeshLambertMaterial({ color: 0x111315 }));
-gun.castShadow = true; gun.position.set(0.55, 1.25, -0.12);
-armR.add(gun);
-
-player.add(body, head, legL, legR, armL, armR);
-player.position.set(0, 0, 0);
-scene.add(player);
-
-// Player health UI
-let playerHealth = 100;
-const healthEl = document.createElement('div');
-healthEl.className = 'health-ui';
-healthEl.textContent = 'Health: 100';
-document.body.appendChild(healthEl);
-function updateHealthUI() {
-  healthEl.textContent = `Health: ${Math.round(playerHealth)}`;
-}
-
-// Rabbits and day/night cycle
-  rabbits = [
-    new Rabbit(scene, player, 1, {
-      onTrap: () => { controls.trappedUntil = performance.now() + 2000; }
-    }, listener, audioLoader),
-    new Rabbit(scene, player, 2, {}, listener, audioLoader),
-    new Rabbit(scene, player, 3, {
-      onAttack: () => { playerHealth *= 0.5; updateHealthUI(); }
-    }, listener, audioLoader)
-  ];
-  initSettings(rabbits, listener, renderer.domElement);
-const dayNight = new DayNightCycle(scene, sun, hemi);
-controls.trappedUntil = 0;
-
-// Camera offset relative to player in local space (over‑the‑shoulder)
-const camOffset = new THREE.Vector3(1.6, 1.8, 3.8); // right shoulder & back
-
-// --- Bullets ---
-const bullets = [];
-const bulletGeo = new THREE.SphereGeometry(0.1, 12, 8);
-const bulletMat = new THREE.MeshBasicMaterial({ color: 0xffffee });
-const raycaster = new THREE.Raycaster();
-
-// Dispensers and balls
-const BALL_RADIUS = 0.4;
-const ballGeo = new THREE.SphereGeometry(BALL_RADIUS, 16, 12);
-const ballMat = new THREE.MeshLambertMaterial({ color: 0xffaa33 });
-const dispensers = [
-  { pos: new THREE.Vector3(8, 0, 8), last: 0 },
-  { pos: new THREE.Vector3(-8, 0, -8), last: 0 },
-  { pos: new THREE.Vector3(-8, 0, 8), last: 0 }
-];
-const balls = [];
-let totalDispensed = 0;
-
-// visualize dispensers
-const dispGeo = new THREE.CylinderGeometry(0.5, 0.5, 1, 16);
-const dispMat = new THREE.MeshLambertMaterial({ color: 0x555555 });
-for (const d of dispensers) {
-  const m = new THREE.Mesh(dispGeo, dispMat);
-  m.position.copy(d.pos);
-  m.castShadow = true; m.receiveShadow = true;
-  scene.add(m);
-}
-
-function shootBullet(){
-  // Muzzle position slightly in front/right of player chest, aligned with aim
-  const muzzle = new THREE.Vector3(0.4, 1.3, -0.2);
-  const muzzleWorld = player.localToWorld(muzzle.clone());
-
-  // Raycast from the camera through the screen center (crosshair)
-  raycaster.setFromCamera(new THREE.Vector2(0, 0), camera);
-  const hits = raycaster.intersectObjects(scene.children, true);
-  let hitPoint;
-  for (const h of hits) {
-    // Skip any hits on the player itself
-    let obj = h.object;
-    let skip = false;
-    while (obj) {
-      if (obj === player) { skip = true; break; }
-      obj = obj.parent;
+    if (enemyState.active && !enemyState.visibleWithFlashlight) {
+      exposureDanger += dt;
+    } else {
+      exposureDanger = Math.max(0, exposureDanger - dt * 0.6);
     }
-    if (!skip) { hitPoint = h.point; break; }
-  }
-  if (!hitPoint) {
-    // No hit: use a distant point straight ahead
-    hitPoint = raycaster.ray.at(100, new THREE.Vector3());
-  }
 
-  // Aim from the muzzle toward the raycast point so bullets pass through the crosshair
-  const dir = hitPoint.clone().sub(muzzleWorld).normalize();
-
-  const mesh = new THREE.Mesh(bulletGeo, bulletMat);
-  mesh.position.copy(muzzleWorld);
-  scene.add(mesh);
-
-  bullets.push({ mesh, vel: dir.multiplyScalar(38), born: performance.now() });
-}
-function handleClick(){
-  const onGround = player.position.y <= 0.001;
-  const dragging = rabbits.find(r => r.isDragging);
-  if (dragging && onGround) {
-    dragging.kick();
-  } else {
-    shootBullet();
-  }
-}
-function onPointerLockChange(locked){
-  showSettings(!locked);
-}
-initControls(renderer.domElement, handleClick, onPointerLockChange);
-
-
-
-// --- Movement & simple ground physics ---
-let velY = 0; // vertical velocity for jumping/gravity
-const GRAV = 22;
-
-  function update(dt){
-    dayNight.update(dt);
-    if (dayNight.isNight) {
-      if (nightSound.buffer && !nightSound.isPlaying) nightSound.play();
-    } else if (nightSound.isPlaying) {
-      nightSound.stop();
+    if (gameClock.isComplete() && !won) {
+      won = true;
+      ui.setMessage('6:00 AM! You survived this prototype night.');
+    } else if (enemyState.active && enemyState.visibleWithFlashlight) {
+      ui.setMessage('You spotted it. Keep watching it in the flashlight beam!');
+    } else if (enemyState.active) {
+      ui.setMessage('It is nearby... turn on the flashlight (F)!');
     }
-    const { yaw, pitch, keys } = controls;
-  const now = performance.now();
-  // Move on XZ using yaw (aim direction)
-  const speed = (keys.has('ShiftLeft')||keys.has('ShiftRight')) ? 10 : 6;
-  const forward = new THREE.Vector3(-Math.sin(yaw), 0, -Math.cos(yaw));
-  const right   = new THREE.Vector3(Math.cos(yaw), 0, -Math.sin(yaw));
-  let move = new THREE.Vector3();
-  if (!controls.trappedUntil || now > controls.trappedUntil) {
-    if (keys.has('KeyW')) move.add(forward);
-    if (keys.has('KeyS')) move.add(forward.clone().multiplyScalar(-1));
-    if (keys.has('KeyD')) move.add(right);
-    if (keys.has('KeyA')) move.add(right.clone().multiplyScalar(-1));
-    if (move.lengthSq()>0) move.normalize().multiplyScalar(speed*dt);
-  }
 
-  player.position.add(move);
-
-  // Jump
-  const onGround = player.position.y <= 0.0 + 0.001;
-  if (onGround) { player.position.y = 0; velY = 0; }
-  if (onGround && keys.has('Space')) velY = 7.5;
-  velY -= GRAV * dt;
-  player.position.y += velY * dt;
-  if (player.position.y < 0) { player.position.y = 0; velY = 0; }
-
-  // Rotate player body to face yaw (torso only for a simple look)
-  player.rotation.y = yaw;
-
-  // Aim the right arm toward where camera looks (rough)
-  armR.rotation.x = pitch * 0.75;
-
-  // Update camera to orbit around player
-    const camRot = new THREE.Euler(pitch, yaw, 0, 'YXZ');
-    const offsetWorld = camOffset.clone().applyEuler(camRot);
-    const camPos = player.position.clone().add(offsetWorld);
-    camera.position.lerp(camPos, 0.85);
-    const camQuat = new THREE.Quaternion().setFromEuler(camRot);
-    camera.quaternion.slerp(camQuat, 0.85);
-
-  // Spawn balls from dispensers
-  for (const d of dispensers) {
-    if (totalDispensed >= gameSettings.maxBalls) break;
-    const interval = 1000 / gameSettings.dispenserRate;
-    if (now - d.last >= interval) {
-      const mesh = new THREE.Mesh(ballGeo, ballMat);
-      mesh.position.copy(d.pos).add(new THREE.Vector3(0, BALL_RADIUS, 0));
-      mesh.castShadow = true; mesh.receiveShadow = true;
-      scene.add(mesh);
-      const dir = new THREE.Vector3(Math.random() - 0.5, 0.5, Math.random() - 0.5).normalize();
-      balls.push({ mesh, vel: dir.multiplyScalar(6) });
-      d.last = now;
-      totalDispensed++;
+    if (exposureDanger > GAME_CONFIG.enemyGraceSeconds) {
+      ui.setMessage('JUMPSCARE! You lost this round. Refresh to retry.');
+      return;
     }
-  }
 
-  // Update balls
-  for (let i = balls.length - 1; i >= 0; i--) {
-    const b = balls[i];
-    b.vel.y -= GRAV * dt;
-    b.mesh.position.addScaledVector(b.vel, dt);
-    if (b.mesh.position.y < BALL_RADIUS) {
-      b.mesh.position.y = BALL_RADIUS;
-      b.vel.y *= -0.6;
-    }
-    if (b.mesh.position.length() > groundSize) {
-      scene.remove(b.mesh); balls.splice(i,1);
-    }
-    // collision with rabbits
-    for (const r of rabbits) {
-      if (!r.visible) continue;
-      const radius = BALL_RADIUS * b.mesh.scale.x;
-      if (r.mesh.position.distanceTo(b.mesh.position) < radius + 1) {
-        r.hitByBall(gameSettings.ballDamage);
-        scene.remove(b.mesh); balls.splice(i,1);
-        break;
-      }
-    }
-  }
+    renderer.render(scene, camera);
+    requestAnimationFrame(update);
+  };
 
-  // Bullets update and collision with balls
-  for (let i=bullets.length-1;i>=0;i--){
-    const b = bullets[i];
-    b.mesh.position.addScaledVector(b.vel, dt);
-    const life = (now - b.born) / 3000;
-    b.mesh.scale.setScalar(Math.max(0, 1 - life));
-    if (life > 1 || b.mesh.position.length() > groundSize) {
-      scene.remove(b.mesh); bullets.splice(i,1); continue;
-    }
-    for (let j = balls.length - 1; j >= 0; j--) {
-      const ball = balls[j];
-      const radius = BALL_RADIUS * ball.mesh.scale.x;
-      if (b.mesh.position.distanceTo(ball.mesh.position) < radius + 0.1) {
-        ball.mesh.scale.multiplyScalar(0.7);
-        scene.remove(b.mesh); bullets.splice(i,1);
-        if (ball.mesh.scale.x < 0.2) {
-          scene.remove(ball.mesh); balls.splice(j,1);
-        }
-        break;
-      }
-    }
-    if (!bullets[i]) continue;
-    for (const r of rabbits) {
-      if (!r.visible) continue;
-      if (b.mesh.position.distanceTo(r.mesh.position) < 2) {
-        r.damage(gameSettings.bulletDamage);
-        scene.remove(b.mesh); bullets.splice(i,1);
-        break;
-      }
-    }
-  }
-
-  for (const r of rabbits) {
-    r.update(dt, dayNight.isNight, camera);
-  }
-}
-
-// --- Animate ---
-let last = performance.now();
-function animate(){
-  const now = performance.now();
-  const dt = Math.min(0.033, (now - last)/1000);
-  last = now;
-  update(dt);
-  renderer.render(scene, camera);
-  requestAnimationFrame(animate);
-}
-
-// Spawn position and initial camera placement
-  player.position.set(0,0,8);
-  camera.position.copy(player.position).add(camOffset);
-  camera.quaternion.setFromEuler(new THREE.Euler(0,0,0));
-
-// Resize
-addEventListener('resize', ()=>{
-  camera.aspect = innerWidth/innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(innerWidth, innerHeight);
-});
-
-animate();
-
+  requestAnimationFrame(update);
 }

--- a/js/input.js
+++ b/js/input.js
@@ -1,0 +1,32 @@
+export function createInput() {
+  const pressed = new Set();
+  let flashlightOn = false;
+  let helpVisible = true;
+
+  window.addEventListener('keydown', (event) => {
+    const { code } = event;
+    pressed.add(code);
+
+    if (code === 'KeyF') {
+      flashlightOn = !flashlightOn;
+    }
+
+    if (code === 'KeyH') {
+      helpVisible = !helpVisible;
+      document.getElementById('instructions').style.display = helpVisible ? 'block' : 'none';
+    }
+  });
+
+  window.addEventListener('keyup', (event) => {
+    pressed.delete(event.code);
+  });
+
+  return {
+    isDown(code) {
+      return pressed.has(code);
+    },
+    isFlashlightOn() {
+      return flashlightOn;
+    }
+  };
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,2 +1,3 @@
 import { startGame } from './game.js';
+
 startGame();

--- a/js/scene.js
+++ b/js/scene.js
@@ -1,0 +1,69 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+
+export function createScene(container) {
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  container.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x050508);
+
+  const camera = new THREE.PerspectiveCamera(58, window.innerWidth / window.innerHeight, 0.1, 100);
+  camera.position.set(0, 1.8, 8.2);
+
+  const ambience = new THREE.AmbientLight(0x223344, 0.5);
+  scene.add(ambience);
+
+  const roomLight = new THREE.PointLight(0x7788aa, 0.7, 18);
+  roomLight.position.set(0, 2.5, 4.5);
+  scene.add(roomLight);
+
+  const flashlight = new THREE.SpotLight(0xfff4c2, 0, 30, 0.28, 0.5, 1);
+  flashlight.position.set(0, 1.7, 7.8);
+  flashlight.target.position.set(0, 1.4, 0);
+  scene.add(flashlight);
+  scene.add(flashlight.target);
+
+  // Office built from simple geometry placeholders.
+  const wallMat = new THREE.MeshStandardMaterial({ color: 0x21252f });
+  const floorMat = new THREE.MeshStandardMaterial({ color: 0x161921 });
+  const deskMat = new THREE.MeshStandardMaterial({ color: 0x363c49 });
+
+  const floor = new THREE.Mesh(new THREE.PlaneGeometry(16, 16), floorMat);
+  floor.rotation.x = -Math.PI / 2;
+  scene.add(floor);
+
+  const backWall = new THREE.Mesh(new THREE.PlaneGeometry(16, 8), wallMat);
+  backWall.position.set(0, 4, -5.2);
+  scene.add(backWall);
+
+  const leftWall = new THREE.Mesh(new THREE.PlaneGeometry(10, 8), wallMat);
+  leftWall.position.set(-8, 4, -0.2);
+  leftWall.rotation.y = Math.PI / 2;
+  scene.add(leftWall);
+
+  const rightWall = leftWall.clone();
+  rightWall.position.x = 8;
+  rightWall.rotation.y = -Math.PI / 2;
+  scene.add(rightWall);
+
+  const desk = new THREE.Mesh(new THREE.BoxGeometry(8, 1.2, 2.4), deskMat);
+  desk.position.set(0, 0.6, 4.7);
+  scene.add(desk);
+
+  const monitor = new THREE.Mesh(
+    new THREE.BoxGeometry(2.4, 1.5, 0.2),
+    new THREE.MeshStandardMaterial({ color: 0x111319, emissive: 0x1f2b47, emissiveIntensity: 0.4 })
+  );
+  monitor.position.set(0, 1.95, 3.7);
+  scene.add(monitor);
+
+  window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  });
+
+  return { scene, camera, renderer, flashlight };
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,24 @@
+export function createUI() {
+  const clockEl = document.getElementById('clock');
+  const flashlightEl = document.getElementById('flashlight-indicator');
+  const eventLogEl = document.getElementById('event-log');
+  const closeHelp = document.getElementById('close-help');
+  const instructions = document.getElementById('instructions');
+
+  closeHelp.addEventListener('click', () => {
+    instructions.style.display = 'none';
+  });
+
+  return {
+    setClock(label) {
+      clockEl.textContent = label;
+    },
+    setFlashlight(on) {
+      flashlightEl.textContent = `Flashlight: ${on ? 'ON' : 'OFF'}`;
+      flashlightEl.classList.toggle('on', on);
+    },
+    setMessage(msg) {
+      eventLogEl.textContent = msg;
+    }
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Five Nights at Freddy's style prototype using Three.js with a simple office scene, flashlight mechanic, and timed enemy appearances. 
- Break the previous single-file approach into small, testable modules so the prototype is easier to iterate on and extend. 

### Description
- Add a streamlined HTML shell (`index.html`) with HUD, instruction panel, and an event log and wire a minimal entrypoint (`js/main.js`) to start the game. 
- Introduce modular game systems: `js/scene.js` (office placeholders + lighting + flashlight), `js/input.js` (WASD look/lean, F flashlight, H help), `js/clock.js` (maps elapsed seconds to 12:00 AM→6:00 AM), `js/enemy.js` (timed spawns + face reveal using `assets/faces/face2.png`), `js/ui.js` (HUD and messages), and `js/config.js` (tuning constants). 
- Replace the old monolithic `js/game.js` content with an orchestrator that updates camera look/lean, flashlight targeting, clock, enemy visibility (enemy appears around 2/3/4/5 AM), exposure/jumpscare logic, and the 6:00 AM win condition. 
- Use simple placeholder geometry for the office (walls, floor, desk, monitor) so missing art assets are handled without blocking the MVP. 

### Testing
- Ran a syntax check across the new and updated modules with: `node --check js/game.js && node --check js/scene.js && node --check js/enemy.js && node --check js/input.js && node --check js/clock.js && node --check js/ui.js && node --check js/config.js && node --check js/main.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c596a0655483219bed24c4362ddfa3)