### PR TITLE
Three.js Night Shift MVP — modular FNAF-style office, clock, animatronic, controls, and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,138 +1,120 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Low‑Poly Forest Shooter</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Night Shift MVP</title>
   <style>
-    html, body { height: 100%; margin: 0; overflow: hidden; background: #202428; }
-    #app { position: fixed; inset: 0; }
-    canvas { display: block; }
-    .ui {
-      position: fixed; left: 50%; transform: translateX(-50%);
-      bottom: 16px; padding: 10px 14px; border-radius: 14px;
-      background: rgba(20,22,24,0.65); color: #e9eef5; font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
-      user-select: none; pointer-events: none;
+    :root {
+      color-scheme: dark;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     }
-    .ui b { color: #fff; }
-    .crosshair {
-      position: fixed; left: 50%; top: 50%; transform: translate(-50%, -50%);
-      width: 14px; height: 14px; pointer-events: none; opacity: 0.85;
-    }
-    .crosshair:before, .crosshair:after {
-      content: ""; position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
-      background: #e9eef5; border-radius: 2px;
-    }
-    .crosshair:before { width: 14px; height: 2px; }
-    .crosshair:after  { width: 2px; height: 14px; }
-    .hint {
-      position: fixed; top: 16px; left: 50%; transform: translateX(-50%);
-      padding: 10px 14px; border-radius: 14px; color: #f1f5f9;
-      background: rgba(0,0,0,0.45); backdrop-filter: blur(4px);
-      font: 13px/1.3 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35);
-      text-align: center;
-    }
-    .hidden { display: none; }
-
-    .settings {
-      position: fixed;
-      top: 50%; left: 50%; transform: translate(-50%, -50%);
-      padding: 24px 30px; border-radius: 14px;
-      background: radial-gradient(circle at top, rgba(40,44,52,0.95), rgba(20,22,24,0.95));
-      border: 1px solid rgba(255,255,255,0.1);
-      color: #e9eef5;
-      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.45); backdrop-filter: blur(6px);
-      min-width: 320px;
-    }
-    .settings h2 {
-      margin: 0 0 10px 0; text-align: center;
-    }
-    .setting {
-      display: flex; align-items: center; margin: 8px 0;
-    }
-    .setting label { flex: 1; margin-right: 10px; }
-    .setting input[type=range] { flex: 2; accent-color: #2ecc71; }
-    .setting .value-input {
-      margin-left: 8px;
-      width: 60px;
-      text-align: right;
-      background: rgba(0,0,0,0.3);
-      border: 1px solid #555;
-      border-radius: 6px;
-      color: #fff;
-      padding: 2px 4px;
-    }
-
-    button#resumeButton {
-      background: #2ecc71;
-      border: none;
-      color: #fff;
-      padding: 8px 16px;
-      border-radius: 8px;
-      cursor: pointer;
-    }
-    button#resumeButton:hover { background: #27ae60; }
-
-    .cycle-ui {
-      position: fixed; top: 16px; right: 16px;
-      width: 60px; height: 60px;
-    }
-    .cycle-ui svg { width: 100%; height: 100%; }
-    .cycle-ui .bg { stroke: rgba(255,255,255,0.25); stroke-width:4; fill:none; }
-    .cycle-ui .progress { stroke:#fff; stroke-width:4; fill:none; transform: rotate(-90deg); transform-origin: 50% 50%; }
-    .cycle-icon { position: absolute; top:50%; left:50%; transform: translate(-50%, -50%); font-size:24px; }
-    .health-ui {
-      position: fixed; bottom: 16px; left: 16px;
-      padding: 8px 12px; border-radius: 10px;
-      background: rgba(20,22,24,0.65); color: #e9eef5;
-      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.35); backdrop-filter: blur(6px);
-      user-select: none;
-    }
-    .rabbit-health {
-      position: fixed;
-      width: 60px;
-      height: 8px;
-      background: rgba(80,0,0,0.8);
-      border: 1px solid #300;
-      pointer-events: none;
-    }
-    .rabbit-health .fill {
-      background: #2ecc71;
-      height: 100%;
+    html, body {
+      margin: 0;
       width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: #060606;
     }
-    .rabbit-health .label {
+    #app, canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+    .hud {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      color: #e8edf8;
+    }
+    .clock {
       position: absolute;
-      top: -14px;
+      top: 16px;
+      right: 20px;
+      padding: 8px 12px;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255,255,255,0.25);
+      border-radius: 8px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+    }
+    .flashlight {
+      position: absolute;
+      top: 16px;
+      left: 20px;
+      padding: 8px 12px;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255,255,255,0.25);
+      border-radius: 8px;
+      font-weight: 600;
+    }
+    .look-indicator {
+      position: absolute;
+      bottom: 20px;
       left: 50%;
       transform: translateX(-50%);
-      color: #fff;
-      font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      padding: 8px 14px;
+      background: rgba(0, 0, 0, 0.45);
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,0.25);
+      font-size: 13px;
     }
+    .directions {
+      position: fixed;
+      width: min(420px, calc(100vw - 32px));
+      left: 16px;
+      bottom: 16px;
+      background: rgba(8, 8, 10, 0.78);
+      border: 1px solid rgba(255,255,255,0.18);
+      border-radius: 10px;
+      padding: 12px 14px;
+      color: #f5f8ff;
+      font-size: 14px;
+      line-height: 1.35;
+    }
+    .directions h2 {
+      margin: 0 0 8px;
+      font-size: 15px;
+    }
+    .directions p {
+      margin: 4px 0;
+    }
+    .event-msg {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: clamp(20px, 4vw, 34px);
+      font-weight: 800;
+      letter-spacing: 1px;
+      color: #ff5050;
+      text-shadow: 0 0 10px rgba(0,0,0,0.9);
+      opacity: 0;
+      transition: opacity 180ms;
+      pointer-events: none;
+    }
+    .event-msg.visible { opacity: 1; }
   </style>
 </head>
 <body>
   <div id="app"></div>
-  <div class="crosshair"></div>
-    <div class="hint" id="hint">Click to lock the mouse (<b>Esc</b> to release). <b>WASD</b> to move, <b>Mouse</b> to aim, <b>Left Click</b> to shoot, <b>Space</b> to jump.</div>
-  <div class="ui">Low‑poly forest • third‑person shooter vibe (generic character, Fortnite‑style POV)</div>
 
-  <div id="settings" class="settings hidden">
-    <h2>Settings</h2>
-    <div class="setting"><label for="volumeSlider">Volume</label><input type="range" id="volumeSlider" min="0" max="1" step="0.01" value="0.5" /> <input type="number" id="volumeLabel" min="0" max="1" step="0.01" value="0.5" class="value-input" /></div>
-    <div class="setting"><label for="faceSlider">Face Offset</label><input type="range" id="faceSlider" min="0" max="1" step="0.01" value="1" /> <input type="number" id="faceLabel" min="0" max="1" step="0.01" value="1" class="value-input" /></div>
-    <div class="setting"><label for="rabbitHealthSlider">Rabbit Max Health</label><input type="range" id="rabbitHealthSlider" min="100" max="1000" value="146" /> <input type="number" id="rabbitHealthLabel" min="100" max="1000" step="1" value="146" class="value-input" /></div>
-    <div class="setting"><label for="bulletDamageSlider">Bullet Damage</label><input type="range" id="bulletDamageSlider" min="1" max="200" value="200" /> <input type="number" id="bulletDamageLabel" min="1" max="200" step="1" value="200" class="value-input" /></div>
-    <div class="setting"><label for="ballDamageSlider">Ball Damage</label><input type="range" id="ballDamageSlider" min="1" max="200" value="10" /> <input type="number" id="ballDamageLabel" min="1" max="200" step="1" value="10" class="value-input" /></div>
-    <div class="setting"><label for="ballRateSlider">Dispenser Rate</label><input type="range" id="ballRateSlider" min="0.1" max="5" step="0.1" value="1" /> <input type="number" id="ballRateLabel" min="0.1" max="5" step="0.1" value="1" class="value-input" /></div>
-    <div class="setting"><label for="ballSlider">Max Balls</label><input type="range" id="ballSlider" min="100" max="10000" value="2020" step="10" /> <input type="number" id="ballCountLabel" min="100" max="10000" step="10" value="2020" class="value-input" /></div>
-    <div style="text-align:center;margin-top:12px;"><button id="resumeButton">Resume</button></div>
+  <div class="hud">
+    <div id="clock" class="clock">12 AM</div>
+    <div id="flashlight" class="flashlight">Flashlight: OFF</div>
+    <div id="lookIndicator" class="look-indicator">View: Center</div>
   </div>
 
-  <script type="module" src="js/main.js"></script>
+  <aside class="directions">
+    <h2>Night Shift Directions</h2>
+    <p><b>A / D</b> (or <b>← / →</b>) to look Left and Right in the office.</p>
+    <p><b>F</b> or hold <b>Space</b> to use the flashlight.</p>
+    <p>The animatronic appears around <b>2 AM, 3 AM, 4 AM, and 5 AM</b>. Flash it quickly.</p>
+    <p>Survive until <b>6 AM</b>.</p>
+  </aside>
+
+  <div id="eventMessage" class="event-msg"></div>
+
+  <script type="module" src="./js/main.js"></script>
 </body>
 </html>

--- a/js/animatronic.js
+++ b/js/animatronic.js
@@ -1,0 +1,66 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+
+const LANE_POSITION = {
+  left: -3.2,
+  center: 0,
+  right: 3.2,
+};
+
+export class Animatronic {
+  constructor(scene) {
+    this.scene = scene;
+    this.loader = new THREE.TextureLoader();
+    this.mesh = null;
+    this.active = false;
+    this.lane = 'center';
+    this.visibleTimer = 0;
+    this.hitWithFlashlight = false;
+
+    const options = ['assets/faces/face1.png', 'assets/faces/face2.png', 'assets/faces/face3.png'];
+    const chosen = options[Math.floor(Math.random() * options.length)];
+    const texture = this.loader.load(chosen);
+
+    this.mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(2.4, 2.8),
+      new THREE.MeshBasicMaterial({ map: texture, transparent: true, opacity: 0 })
+    );
+    this.mesh.position.set(0, 1.7, -7.6);
+    this.scene.add(this.mesh);
+  }
+
+  spawn() {
+    this.active = true;
+    this.hitWithFlashlight = false;
+    this.visibleTimer = 0;
+    const lanes = ['left', 'center', 'right'];
+    this.lane = lanes[Math.floor(Math.random() * lanes.length)];
+    this.mesh.position.x = LANE_POSITION[this.lane];
+    this.mesh.material.opacity = 0;
+  }
+
+  hide() {
+    this.active = false;
+    this.mesh.material.opacity = 0;
+  }
+
+  update(deltaSeconds, { playerView, flashlightOn }) {
+    if (!this.active) return { jumpscare: false, flashedAway: false };
+
+    this.visibleTimer += deltaSeconds;
+    const inSight = playerView === this.lane;
+    const visible = inSight && flashlightOn;
+    this.mesh.material.opacity = visible ? 1 : 0;
+
+    if (visible) {
+      this.hitWithFlashlight = true;
+      this.hide();
+      return { jumpscare: false, flashedAway: true };
+    }
+
+    if (this.visibleTimer > 5.5 && !this.hitWithFlashlight) {
+      return { jumpscare: true, flashedAway: false };
+    }
+
+    return { jumpscare: false, flashedAway: false };
+  }
+}

--- a/js/clock.js
+++ b/js/clock.js
@@ -1,0 +1,25 @@
+import { HOUR_LENGTH_SECONDS, GAME_HOURS } from './constants.js';
+
+export class NightClock {
+  constructor() {
+    this.elapsed = 0;
+  }
+
+  update(deltaSeconds) {
+    this.elapsed += deltaSeconds;
+  }
+
+  getHour() {
+    const index = Math.min(Math.floor(this.elapsed / HOUR_LENGTH_SECONDS), GAME_HOURS.length - 1);
+    return GAME_HOURS[index];
+  }
+
+  formatHour() {
+    const hour = this.getHour();
+    return `${hour} AM`;
+  }
+
+  isComplete() {
+    return this.getHour() >= 6;
+  }
+}

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,15 @@
+export const GAME_HOURS = [12, 1, 2, 3, 4, 5, 6];
+export const HOUR_LENGTH_SECONDS = 20;
+export const ANIMATRONIC_SPAWN_HOURS = [2, 3, 4, 5];
+
+export const VIEW_ANGLES = {
+  left: 0.42,
+  center: 0,
+  right: -0.42,
+};
+
+export const VIEW_LABELS = {
+  left: 'Left',
+  center: 'Center',
+  right: 'Right',
+};

--- a/js/controls.js
+++ b/js/controls.js
@@ -1,44 +1,24 @@
-export const controls = {
-  yaw: 0,
-  pitch: 0,
-  keys: new Set(),
-  pointerLocked: false,
-  allowPointerLock: true
-};
+export class Controls {
+  constructor() {
+    this.view = 'center';
+    this.flashlightHeld = false;
+    this.flashlightToggle = false;
 
-export function initControls(domElement, shoot, onPointerLockChange) {
-  const hint = document.getElementById('hint');
-  addEventListener('keydown', e => {
-    if (e.code === 'Escape' && controls.pointerLocked) {
-      document.exitPointerLock();
-    } else {
-      controls.keys.add(e.code);
-    }
-  });
-  addEventListener('keyup', e => {
-    controls.keys.delete(e.code);
-  });
+    addEventListener('keydown', (event) => {
+      if (event.code === 'KeyA' || event.code === 'ArrowLeft') this.view = 'left';
+      if (event.code === 'KeyD' || event.code === 'ArrowRight') this.view = 'right';
+      if (event.code === 'KeyF') this.flashlightToggle = !this.flashlightToggle;
+      if (event.code === 'Space') this.flashlightHeld = true;
+    });
 
-  domElement.addEventListener('mousedown', e => {
-    if (controls.pointerLocked) {
-      if (e.button === 0) shoot();
-    } else if (controls.allowPointerLock) {
-      domElement.requestPointerLock();
-      e.preventDefault();
-    }
-  });
+    addEventListener('keyup', (event) => {
+      if (event.code === 'Space') this.flashlightHeld = false;
+      if ((event.code === 'KeyA' || event.code === 'ArrowLeft') && this.view === 'left') this.view = 'center';
+      if ((event.code === 'KeyD' || event.code === 'ArrowRight') && this.view === 'right') this.view = 'center';
+    });
+  }
 
-  document.addEventListener('pointerlockchange', () => {
-    controls.pointerLocked = document.pointerLockElement === domElement;
-    hint.classList.toggle('hidden', controls.pointerLocked);
-    if (onPointerLockChange) onPointerLockChange(controls.pointerLocked);
-  });
-
-  addEventListener('mousemove', e => {
-    if (!controls.pointerLocked) return;
-    const sensitivity = 0.0027;
-    controls.yaw   -= e.movementX * sensitivity;
-    controls.pitch -= e.movementY * sensitivity;
-    controls.pitch = Math.max(-Math.PI/3, Math.min(Math.PI/3, controls.pitch));
-  });
+  isFlashlightOn() {
+    return this.flashlightHeld || this.flashlightToggle;
+  }
 }

--- a/js/game.js
+++ b/js/game.js
@@ -1,391 +1,82 @@
-import { controls, initControls } from "./controls.js";
-import { DayNightCycle } from './dayNight.js';
-import { Rabbit } from './rabbit.js';
-import { initSettings, showSettings, gameSettings } from './settings.js';
 import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
-export function startGame() {
+import { NightClock } from './clock.js';
+import { Controls } from './controls.js';
+import { OfficeScene } from './officeScene.js';
+import { Animatronic } from './animatronic.js';
+import { UI } from './ui.js';
+import { ANIMATRONIC_SPAWN_HOURS } from './constants.js';
 
-// --- Renderer & Scene ---
-const app = document.getElementById('app');
-const renderer = new THREE.WebGLRenderer({ antialias: true });
-renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
-renderer.setSize(innerWidth, innerHeight);
-renderer.shadowMap.enabled = true;
-app.appendChild(renderer.domElement);
+export class Game {
+  constructor(mountNode) {
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+    this.renderer.setSize(innerWidth, innerHeight);
+    mountNode.appendChild(this.renderer.domElement);
 
-let rabbits = [];
+    this.office = new OfficeScene();
+    this.clock = new NightClock();
+    this.controls = new Controls();
+    this.ui = new UI();
+    this.animatronic = new Animatronic(this.office.scene);
 
-const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x7fb0ff);
-scene.fog = new THREE.Fog(0x7fb0ff, 20, 140);
+    this.lastFrame = performance.now();
+    this.spawnedAtHours = new Set();
+    this.gameOver = false;
 
-  // --- Camera (third‑person follow) ---
-  const camera = new THREE.PerspectiveCamera(70, innerWidth/innerHeight, 0.1, 500);
-
-  // Audio setup
-  const listener = new THREE.AudioListener();
-  camera.add(listener);
-  const audioLoader = new THREE.AudioLoader();
-  const nightSound = new THREE.Audio(listener);
-  audioLoader.load('audio/horror-drone.wav', (buffer) => {
-    nightSound.setBuffer(buffer);
-    nightSound.setLoop(true);
-    nightSound.setVolume(1.0);
-  });
-
-// --- Lights ---
-const hemi = new THREE.HemisphereLight(0xffffff, 0x335533, 0.6);
-scene.add(hemi);
-
-const sun = new THREE.DirectionalLight(0xffffff, 1.0);
-sun.position.set(40, 60, 20);
-sun.castShadow = true;
-sun.shadow.mapSize.set(2048, 2048);
-sun.shadow.camera.near = 1;
-sun.shadow.camera.far = 200;
-sun.shadow.camera.left = -80;
-sun.shadow.camera.right = 80;
-sun.shadow.camera.top = 80;
-sun.shadow.camera.bottom = -80;
-scene.add(sun);
-
-// --- Ground ---
-const groundSize = 240;
-const groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, 1, 1);
-const groundMat = new THREE.MeshLambertMaterial({ color: 0x6dbb4b }); // grassy green
-const ground = new THREE.Mesh(groundGeo, groundMat);
-ground.rotation.x = -Math.PI/2;
-ground.receiveShadow = true;
-scene.add(ground);
-
-// --- Low‑poly Tree Factory ---
-function makeTree() {
-  const group = new THREE.Group();
-  const trunk = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.25, 0.35, 2.5, 6),
-    new THREE.MeshLambertMaterial({ color: 0x8b5a2b })
-  );
-  trunk.castShadow = true; trunk.receiveShadow = true;
-  trunk.position.y = 1.25;
-
-  const foliage = new THREE.Mesh(
-    new THREE.ConeGeometry(1.6, 3.2, 6),
-    new THREE.MeshLambertMaterial({ color: 0x2f8f46 })
-  );
-  foliage.castShadow = true; foliage.receiveShadow = true;
-  foliage.position.y = 1.25 + 1.6;
-
-  const cap = new THREE.Mesh(
-    new THREE.ConeGeometry(1.2, 2.2, 6),
-    new THREE.MeshLambertMaterial({ color: 0x2a7a3d })
-  );
-  cap.castShadow = true; cap.receiveShadow = true;
-  cap.position.y = foliage.position.y + 1.1;
-
-  group.add(trunk, foliage, cap);
-  return group;
-}
-
-// Scatter trees but keep a clearing near the spawn
-const rng = (min,max)=>Math.random()*(max-min)+min;
-const trees = [];
-for (let i=0;i<220;i++){
-  const t = makeTree();
-  const r = groundSize*0.48;
-  let x, z; let tries = 0;
-  do {
-    x = rng(-r, r); z = rng(-r, r); tries++;
-  } while (tries < 50 && Math.hypot(x, z) < 12); // keep spawn clearing
-  t.position.set(x, 0, z);
-  t.rotation.y = rng(0, Math.PI*2);
-  const s = rng(0.8, 1.4); t.scale.setScalar(s);
-  trees.push(t);
-  scene.add(t);
-}
-
-// --- Player (generic low‑poly, Fortnite‑inspired POV) ---
-const player = new THREE.Group();
-
-// Body parts
-const body = new THREE.Mesh(new THREE.BoxGeometry(0.9, 1.2, 0.5), new THREE.MeshLambertMaterial({ color: 0x3b82f6 }));
-body.position.y = 1.1; body.castShadow = true; body.receiveShadow = true;
-
-const head = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.5, 0.5), new THREE.MeshLambertMaterial({ color: 0xf1f5f9 }));
-head.position.y = 1.1 + 0.85; head.castShadow = true;
-
-const legL = new THREE.Mesh(new THREE.BoxGeometry(0.35, 0.9, 0.35), new THREE.MeshLambertMaterial({ color: 0x1f2937 }));
-const legR = legL.clone();
-legL.position.set(-0.22, 0.45, 0);
-legR.position.set( 0.22, 0.45, 0);
-
-const armL = new THREE.Mesh(new THREE.BoxGeometry(0.25, 0.9, 0.25), new THREE.MeshLambertMaterial({ color: 0x3b82f6 }));
-const armR = armL.clone();
-armL.position.set(-0.6, 1.2, 0);
-armR.position.set( 0.6, 1.2, 0);
-
-// Simple blaster
-const gun = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.2, 0.2), new THREE.MeshLambertMaterial({ color: 0x111315 }));
-gun.castShadow = true; gun.position.set(0.55, 1.25, -0.12);
-armR.add(gun);
-
-player.add(body, head, legL, legR, armL, armR);
-player.position.set(0, 0, 0);
-scene.add(player);
-
-// Player health UI
-let playerHealth = 100;
-const healthEl = document.createElement('div');
-healthEl.className = 'health-ui';
-healthEl.textContent = 'Health: 100';
-document.body.appendChild(healthEl);
-function updateHealthUI() {
-  healthEl.textContent = `Health: ${Math.round(playerHealth)}`;
-}
-
-// Rabbits and day/night cycle
-  rabbits = [
-    new Rabbit(scene, player, 1, {
-      onTrap: () => { controls.trappedUntil = performance.now() + 2000; }
-    }, listener, audioLoader),
-    new Rabbit(scene, player, 2, {}, listener, audioLoader),
-    new Rabbit(scene, player, 3, {
-      onAttack: () => { playerHealth *= 0.5; updateHealthUI(); }
-    }, listener, audioLoader)
-  ];
-  initSettings(rabbits, listener, renderer.domElement);
-const dayNight = new DayNightCycle(scene, sun, hemi);
-controls.trappedUntil = 0;
-
-// Camera offset relative to player in local space (over‑the‑shoulder)
-const camOffset = new THREE.Vector3(1.6, 1.8, 3.8); // right shoulder & back
-
-// --- Bullets ---
-const bullets = [];
-const bulletGeo = new THREE.SphereGeometry(0.1, 12, 8);
-const bulletMat = new THREE.MeshBasicMaterial({ color: 0xffffee });
-const raycaster = new THREE.Raycaster();
-
-// Dispensers and balls
-const BALL_RADIUS = 0.4;
-const ballGeo = new THREE.SphereGeometry(BALL_RADIUS, 16, 12);
-const ballMat = new THREE.MeshLambertMaterial({ color: 0xffaa33 });
-const dispensers = [
-  { pos: new THREE.Vector3(8, 0, 8), last: 0 },
-  { pos: new THREE.Vector3(-8, 0, -8), last: 0 },
-  { pos: new THREE.Vector3(-8, 0, 8), last: 0 }
-];
-const balls = [];
-let totalDispensed = 0;
-
-// visualize dispensers
-const dispGeo = new THREE.CylinderGeometry(0.5, 0.5, 1, 16);
-const dispMat = new THREE.MeshLambertMaterial({ color: 0x555555 });
-for (const d of dispensers) {
-  const m = new THREE.Mesh(dispGeo, dispMat);
-  m.position.copy(d.pos);
-  m.castShadow = true; m.receiveShadow = true;
-  scene.add(m);
-}
-
-function shootBullet(){
-  // Muzzle position slightly in front/right of player chest, aligned with aim
-  const muzzle = new THREE.Vector3(0.4, 1.3, -0.2);
-  const muzzleWorld = player.localToWorld(muzzle.clone());
-
-  // Raycast from the camera through the screen center (crosshair)
-  raycaster.setFromCamera(new THREE.Vector2(0, 0), camera);
-  const hits = raycaster.intersectObjects(scene.children, true);
-  let hitPoint;
-  for (const h of hits) {
-    // Skip any hits on the player itself
-    let obj = h.object;
-    let skip = false;
-    while (obj) {
-      if (obj === player) { skip = true; break; }
-      obj = obj.parent;
-    }
-    if (!skip) { hitPoint = h.point; break; }
-  }
-  if (!hitPoint) {
-    // No hit: use a distant point straight ahead
-    hitPoint = raycaster.ray.at(100, new THREE.Vector3());
+    addEventListener('resize', () => {
+      this.renderer.setSize(innerWidth, innerHeight);
+      this.office.resize();
+    });
   }
 
-  // Aim from the muzzle toward the raycast point so bullets pass through the crosshair
-  const dir = hitPoint.clone().sub(muzzleWorld).normalize();
+  tick = (now) => {
+    const dt = Math.min((now - this.lastFrame) / 1000, 0.1);
+    this.lastFrame = now;
 
-  const mesh = new THREE.Mesh(bulletGeo, bulletMat);
-  mesh.position.copy(muzzleWorld);
-  scene.add(mesh);
+    if (!this.gameOver) {
+      this.clock.update(dt);
+      const hour = this.clock.getHour();
 
-  bullets.push({ mesh, vel: dir.multiplyScalar(38), born: performance.now() });
-}
-function handleClick(){
-  const onGround = player.position.y <= 0.001;
-  const dragging = rabbits.find(r => r.isDragging);
-  if (dragging && onGround) {
-    dragging.kick();
-  } else {
-    shootBullet();
-  }
-}
-function onPointerLockChange(locked){
-  showSettings(!locked);
-}
-initControls(renderer.domElement, handleClick, onPointerLockChange);
-
-
-
-// --- Movement & simple ground physics ---
-let velY = 0; // vertical velocity for jumping/gravity
-const GRAV = 22;
-
-  function update(dt){
-    dayNight.update(dt);
-    if (dayNight.isNight) {
-      if (nightSound.buffer && !nightSound.isPlaying) nightSound.play();
-    } else if (nightSound.isPlaying) {
-      nightSound.stop();
-    }
-    const { yaw, pitch, keys } = controls;
-  const now = performance.now();
-  // Move on XZ using yaw (aim direction)
-  const speed = (keys.has('ShiftLeft')||keys.has('ShiftRight')) ? 10 : 6;
-  const forward = new THREE.Vector3(-Math.sin(yaw), 0, -Math.cos(yaw));
-  const right   = new THREE.Vector3(Math.cos(yaw), 0, -Math.sin(yaw));
-  let move = new THREE.Vector3();
-  if (!controls.trappedUntil || now > controls.trappedUntil) {
-    if (keys.has('KeyW')) move.add(forward);
-    if (keys.has('KeyS')) move.add(forward.clone().multiplyScalar(-1));
-    if (keys.has('KeyD')) move.add(right);
-    if (keys.has('KeyA')) move.add(right.clone().multiplyScalar(-1));
-    if (move.lengthSq()>0) move.normalize().multiplyScalar(speed*dt);
-  }
-
-  player.position.add(move);
-
-  // Jump
-  const onGround = player.position.y <= 0.0 + 0.001;
-  if (onGround) { player.position.y = 0; velY = 0; }
-  if (onGround && keys.has('Space')) velY = 7.5;
-  velY -= GRAV * dt;
-  player.position.y += velY * dt;
-  if (player.position.y < 0) { player.position.y = 0; velY = 0; }
-
-  // Rotate player body to face yaw (torso only for a simple look)
-  player.rotation.y = yaw;
-
-  // Aim the right arm toward where camera looks (rough)
-  armR.rotation.x = pitch * 0.75;
-
-  // Update camera to orbit around player
-    const camRot = new THREE.Euler(pitch, yaw, 0, 'YXZ');
-    const offsetWorld = camOffset.clone().applyEuler(camRot);
-    const camPos = player.position.clone().add(offsetWorld);
-    camera.position.lerp(camPos, 0.85);
-    const camQuat = new THREE.Quaternion().setFromEuler(camRot);
-    camera.quaternion.slerp(camQuat, 0.85);
-
-  // Spawn balls from dispensers
-  for (const d of dispensers) {
-    if (totalDispensed >= gameSettings.maxBalls) break;
-    const interval = 1000 / gameSettings.dispenserRate;
-    if (now - d.last >= interval) {
-      const mesh = new THREE.Mesh(ballGeo, ballMat);
-      mesh.position.copy(d.pos).add(new THREE.Vector3(0, BALL_RADIUS, 0));
-      mesh.castShadow = true; mesh.receiveShadow = true;
-      scene.add(mesh);
-      const dir = new THREE.Vector3(Math.random() - 0.5, 0.5, Math.random() - 0.5).normalize();
-      balls.push({ mesh, vel: dir.multiplyScalar(6) });
-      d.last = now;
-      totalDispensed++;
-    }
-  }
-
-  // Update balls
-  for (let i = balls.length - 1; i >= 0; i--) {
-    const b = balls[i];
-    b.vel.y -= GRAV * dt;
-    b.mesh.position.addScaledVector(b.vel, dt);
-    if (b.mesh.position.y < BALL_RADIUS) {
-      b.mesh.position.y = BALL_RADIUS;
-      b.vel.y *= -0.6;
-    }
-    if (b.mesh.position.length() > groundSize) {
-      scene.remove(b.mesh); balls.splice(i,1);
-    }
-    // collision with rabbits
-    for (const r of rabbits) {
-      if (!r.visible) continue;
-      const radius = BALL_RADIUS * b.mesh.scale.x;
-      if (r.mesh.position.distanceTo(b.mesh.position) < radius + 1) {
-        r.hitByBall(gameSettings.ballDamage);
-        scene.remove(b.mesh); balls.splice(i,1);
-        break;
+      if (ANIMATRONIC_SPAWN_HOURS.includes(hour) && !this.spawnedAtHours.has(hour)) {
+        this.spawnedAtHours.add(hour);
+        this.animatronic.spawn();
+        this.ui.showEvent('Movement detected in hallway');
       }
-    }
-  }
 
-  // Bullets update and collision with balls
-  for (let i=bullets.length-1;i>=0;i--){
-    const b = bullets[i];
-    b.mesh.position.addScaledVector(b.vel, dt);
-    const life = (now - b.born) / 3000;
-    b.mesh.scale.setScalar(Math.max(0, 1 - life));
-    if (life > 1 || b.mesh.position.length() > groundSize) {
-      scene.remove(b.mesh); bullets.splice(i,1); continue;
-    }
-    for (let j = balls.length - 1; j >= 0; j--) {
-      const ball = balls[j];
-      const radius = BALL_RADIUS * ball.mesh.scale.x;
-      if (b.mesh.position.distanceTo(ball.mesh.position) < radius + 0.1) {
-        ball.mesh.scale.multiplyScalar(0.7);
-        scene.remove(b.mesh); bullets.splice(i,1);
-        if (ball.mesh.scale.x < 0.2) {
-          scene.remove(ball.mesh); balls.splice(j,1);
-        }
-        break;
+      const flashlightOn = this.controls.isFlashlightOn();
+      this.office.setView(this.controls.view);
+      this.office.setFlashlight(flashlightOn);
+
+      const result = this.animatronic.update(dt, {
+        playerView: this.controls.view,
+        flashlightOn,
+      });
+
+      if (result.flashedAway) {
+        this.ui.showEvent('Animatronic repelled');
       }
-    }
-    if (!bullets[i]) continue;
-    for (const r of rabbits) {
-      if (!r.visible) continue;
-      if (b.mesh.position.distanceTo(r.mesh.position) < 2) {
-        r.damage(gameSettings.bulletDamage);
-        scene.remove(b.mesh); bullets.splice(i,1);
-        break;
+      if (result.jumpscare) {
+        this.gameOver = true;
+        this.ui.showEvent('JUMPSCARE - Shift failed', 3000);
       }
+      if (this.clock.isComplete()) {
+        this.gameOver = true;
+        this.animatronic.hide();
+        this.ui.showEvent('6 AM - You survived!', 3500);
+      }
+
+      this.ui.update({
+        hourLabel: this.clock.formatHour(),
+        flashlightOn,
+        view: this.controls.view,
+      });
     }
+
+    this.renderer.render(this.office.scene, this.office.camera);
+    requestAnimationFrame(this.tick);
+  };
+
+  start() {
+    requestAnimationFrame(this.tick);
   }
-
-  for (const r of rabbits) {
-    r.update(dt, dayNight.isNight, camera);
-  }
-}
-
-// --- Animate ---
-let last = performance.now();
-function animate(){
-  const now = performance.now();
-  const dt = Math.min(0.033, (now - last)/1000);
-  last = now;
-  update(dt);
-  renderer.render(scene, camera);
-  requestAnimationFrame(animate);
-}
-
-// Spawn position and initial camera placement
-  player.position.set(0,0,8);
-  camera.position.copy(player.position).add(camOffset);
-  camera.quaternion.setFromEuler(new THREE.Euler(0,0,0));
-
-// Resize
-addEventListener('resize', ()=>{
-  camera.aspect = innerWidth/innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(innerWidth, innerHeight);
-});
-
-animate();
-
 }

--- a/js/main.js
+++ b/js/main.js
@@ -1,2 +1,5 @@
-import { startGame } from './game.js';
-startGame();
+import { Game } from './game.js';
+
+const app = document.getElementById('app');
+const game = new Game(app);
+game.start();

--- a/js/officeScene.js
+++ b/js/officeScene.js
@@ -1,0 +1,78 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+import { VIEW_ANGLES } from './constants.js';
+
+function makeBackdropTexture() {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1024;
+  canvas.height = 512;
+  const ctx = canvas.getContext('2d');
+
+  const grad = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  grad.addColorStop(0, '#181923');
+  grad.addColorStop(1, '#060608');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = '#11131b';
+  ctx.fillRect(0, 320, canvas.width, 192);
+
+  // hallway opening
+  ctx.fillStyle = '#000';
+  ctx.fillRect(390, 120, 244, 240);
+
+  // cheap wall details
+  ctx.strokeStyle = 'rgba(180, 200, 255, 0.16)';
+  ctx.lineWidth = 3;
+  for (let y = 40; y < 300; y += 40) {
+    ctx.beginPath();
+    ctx.moveTo(20, y);
+    ctx.lineTo(350, y);
+    ctx.moveTo(674, y);
+    ctx.lineTo(1004, y);
+    ctx.stroke();
+  }
+
+  return new THREE.CanvasTexture(canvas);
+}
+
+export class OfficeScene {
+  constructor() {
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.PerspectiveCamera(55, innerWidth / innerHeight, 0.1, 100);
+    this.camera.position.set(0, 1.5, 5.7);
+
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.1));
+
+    this.flashlight = new THREE.SpotLight(0xe8f5ff, 0, 30, 0.45, 0.45, 1.1);
+    this.flashlight.position.set(0, 1.55, 5.2);
+    this.flashlight.target.position.set(0, 1.7, -8);
+    this.scene.add(this.flashlight, this.flashlight.target);
+
+    const wall = new THREE.Mesh(
+      new THREE.PlaneGeometry(16, 8),
+      new THREE.MeshLambertMaterial({ map: makeBackdropTexture() })
+    );
+    wall.position.set(0, 2, -8);
+    this.scene.add(wall);
+
+    const desk = new THREE.Mesh(
+      new THREE.BoxGeometry(12, 1.3, 3.5),
+      new THREE.MeshLambertMaterial({ color: 0x20232a })
+    );
+    desk.position.set(0, -0.5, 3);
+    this.scene.add(desk);
+  }
+
+  resize() {
+    this.camera.aspect = innerWidth / innerHeight;
+    this.camera.updateProjectionMatrix();
+  }
+
+  setView(view) {
+    this.camera.rotation.set(0, VIEW_ANGLES[view], 0);
+  }
+
+  setFlashlight(on) {
+    this.flashlight.intensity = on ? 2.5 : 0;
+  }
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,24 @@
+import { VIEW_LABELS } from './constants.js';
+
+export class UI {
+  constructor() {
+    this.clockEl = document.getElementById('clock');
+    this.flashlightEl = document.getElementById('flashlight');
+    this.lookEl = document.getElementById('lookIndicator');
+    this.eventEl = document.getElementById('eventMessage');
+    this.eventTimeout = null;
+  }
+
+  update({ hourLabel, flashlightOn, view }) {
+    this.clockEl.textContent = hourLabel;
+    this.flashlightEl.textContent = `Flashlight: ${flashlightOn ? 'ON' : 'OFF'}`;
+    this.lookEl.textContent = `View: ${VIEW_LABELS[view]}`;
+  }
+
+  showEvent(text, duration = 1200) {
+    this.eventEl.textContent = text;
+    this.eventEl.classList.add('visible');
+    clearTimeout(this.eventTimeout);
+    this.eventTimeout = setTimeout(() => this.eventEl.classList.remove('visible'), duration);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Five Nights at Freddy’s‑style playable prototype using Three.js while keeping the gameplay mostly 2D and easy to extend. 
- Replace the old single‑file runtime with small, focused modules so systems (controls, clock, scene, animatronic, UI) are easier to iterate on. 
- Implement the core night‑shift mechanics (office views, flashlight interaction, timed animatronic events, and simple win/lose conditions) as an MVP. 

### Description
- Added modular game systems: `js/constants.js`, `js/clock.js`, `js/controls.js` (refactored to a `Controls` class), `js/officeScene.js`, `js/animatronic.js`, and `js/ui.js`, and rewired orchestration in `js/game.js` and `js/main.js`. 
- Reworked `index.html` to a compact HUD + directions layout and mounted the Three.js canvas from `js/main.js`. 
- Implemented core mechanics: look left/center/right with `A/D` or arrow keys, flashlight with `F` (toggle) or `Space` (hold), animatronic spawn windows at `2 AM, 3 AM, 4 AM, 5 AM`, a repelling flash mechanic, jumpscare failure, and survival victory at `6 AM`. 
- Created a simple textured office backdrop, a spotlight flashlight, and an animatronic plane that randomly spawns in left/center/right lanes and times out into a jumpscare if not flashed away. 

### Testing
- Ran syntax checks across the new/updated modules using `node --check` (checked `js/main.js`, `js/game.js`, `js/officeScene.js`, `js/animatronic.js`, `js/ui.js`, `js/clock.js`, `js/controls.js`, and `js/constants.js`) and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c596a0655483219bed24c4362ddfa3)